### PR TITLE
feat: tags quickfix list

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ require("grapple").reset("global")
 
 #### `grapple#quickfix`
 
-Open the quickfix list populated with a project scope's tags.
+Open the quickfix menu and populate the quickfix list with a project scope's tags.
 
 **API**: `require("grapple").quickfix(scope)`
 
@@ -360,10 +360,10 @@ Open the quickfix list populated with a project scope's tags.
 **Examples**
 
 ```lua
--- Open the quickfix list for the current scope
+-- Open the quickfix menu for the current scope
 require("grapple").quickfix()
 
--- Open the quickfix list for a specified scope
+-- Open the quickfix menu for a specified scope
 require("grapple").quickfix("global")
 ```
 
@@ -493,7 +493,7 @@ The **tags popup menu** opens a floating window containing all the tags within a
 * **Deletion**: a tag (or tags) can be removed by deleting them from the popup menu (i.e. NORMAL `dd` and VISUAL `d`)
 * **Reordering**: an [anonymous tag](#anonymous-tags) (or tags) can be reordered by moving them up or down within the popup menu. Ordering is determined by the tags position within the popup menu: top (first index) to bottom (last index)
 * **Renaming**: a [named tag](#named-tags) can be renamed by editing its key value between the `[` square brackets `]`
-* **Quickfix (`<c-q>`)**: all tags in an open popup will be sent to the quickfix list, the popup menu closed, and the quickfix list opened
+* **Quickfix (`<c-q>`)**: all tags in an open popup will be [sent to the quickfix list](#grapplequickfix), the popup menu closed, and the quickfix menu opened
 
 **Command**: `:GrapplePopup tags`
 

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ The **tags popup menu** opens a floating window containing all the tags within a
 * **Deletion**: a tag (or tags) can be removed by deleting them from the popup menu (i.e. NORMAL `dd` and VISUAL `d`)
 * **Reordering**: an [anonymous tag](#anonymous-tags) (or tags) can be reordered by moving them up or down within the popup menu. Ordering is determined by the tags position within the popup menu: top (first index) to bottom (last index)
 * **Renaming**: a [named tag](#named-tags) can be renamed by editing its key value between the `[` square brackets `]`
-* **Quickfix (`<c-q>`)**: all tags in an open popup will be [sent to the quickfix list](#grapplequickfix), the popup menu closed, and the quickfix menu opened
+* **Quickfix (`<c-q>`)**: all tags will be [sent to the quickfix list](#grapplequickfix), the popup menu closed, and the quickfix menu opened
 
 **Command**: `:GrapplePopup tags`
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,24 @@ require("grapple").reset()
 require("grapple").reset("global")
 ```
 
+#### `grapple#quickfix`
+
+Open the quickfix list populated with a project scope's tags.
+
+**API**: `require("grapple").quickfix(scope)`
+
+**`scope?`**: [`Grapple.Scope`](#grapplescope) (default: `settings.scope`)
+
+**Examples**
+
+```lua
+-- Open the quickfix list for the current scope
+require("grapple").quickfix()
+
+-- Open the quickfix list for a specified scope
+require("grapple").quickfix("global")
+```
+
 </details>
 
 ### Scope Usage
@@ -475,6 +493,7 @@ The **tags popup menu** opens a floating window containing all the tags within a
 * **Deletion**: a tag (or tags) can be removed by deleting them from the popup menu (i.e. NORMAL `dd` and VISUAL `d`)
 * **Reordering**: an [anonymous tag](#anonymous-tags) (or tags) can be reordered by moving them up or down within the popup menu. Ordering is determined by the tags position within the popup menu: top (first index) to bottom (last index)
 * **Renaming**: a [named tag](#named-tags) can be renamed by editing its key value between the `[` square brackets `]`
+* **Quickfix (`<c-q>`)**: all tags in an open popup will be sent to the quickfix list, the popup menu closed, and the quickfix list opened
 
 **Command**: `:GrapplePopup tags`
 

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -122,6 +122,12 @@ function grapple.reset(scope_)
 end
 
 ---@param scope_? Grapple.Scope
+function grapple.quickfix(scope_)
+    tags.quickfix(scope_ or settings.scope)
+    vim.api.nvim_cmd({ cmd = "copen" }, {})
+end
+
+---@param scope_? Grapple.Scope
 function grapple.popup_tags(scope_)
     scope_ = scope_ or settings.scope
     local window_options = vim.deepcopy(settings.popup_options)

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -124,7 +124,6 @@ end
 ---@param scope_? Grapple.Scope
 function grapple.quickfix(scope_)
     tags.quickfix(scope_ or settings.scope)
-    vim.api.nvim_cmd({ cmd = "copen" }, {})
 end
 
 ---@param scope_? Grapple.Scope

--- a/lua/grapple/popup_tags.lua
+++ b/lua/grapple/popup_tags.lua
@@ -163,6 +163,17 @@ local function action_select(scope_, popup_, parser)
 end
 
 ---@param scope_ Grapple.Scope
+---@param popup_ Grapple.Popup
+---@param parser Grapple.Parser<Grapple.PartialTag>
+local function action_quickfix(scope_, popup_, parser)
+    return function()
+        resolve(scope_, popup_, parser)
+        popup.close(popup_)
+        tags.quickfix(scope_)
+    end
+end
+
+---@param scope_ Grapple.Scope
 ---@param window_options table
 function M.open(scope_, window_options)
     if vim.fn.has("nvim-0.9") == 1 then
@@ -184,11 +195,13 @@ function M.open(scope_, window_options)
 
     local close = action_close(scope_, popup_, parser)
     local select = action_select(scope_, popup_, parser)
+    local quickfix = action_quickfix(scope_, popup_, parser)
 
     local keymap_options = { buffer = popup_.buffer, nowait = true }
     vim.keymap.set("n", "q", close, keymap_options)
     vim.keymap.set("n", "<esc>", close, keymap_options)
     vim.keymap.set("n", "<cr>", select, keymap_options)
+    vim.keymap.set("n", "<c-q>", quickfix, keymap_options)
     popup.on_leave(popup_, close)
 end
 

--- a/lua/grapple/scope.lua
+++ b/lua/grapple/scope.lua
@@ -120,7 +120,7 @@ function scope.root(root_names, opts)
 end
 
 ---@param scope_resolvers Grapple.ScopeResolver[]
----@param opts? string
+---@param opts? Grapple.Options
 ---@return Grapple.ScopeResolver
 function scope.fallback(scope_resolvers, opts)
     return scope.resolver(function()

--- a/lua/grapple/tags.lua
+++ b/lua/grapple/tags.lua
@@ -125,7 +125,6 @@ end
 function tags.quickfix(scope_)
     local quickfix_items = {}
     for tag_key, tag in pairs(_scoped_tags(scope_)) do
-        -- bufnr, filename, lnum, col, text
         local quickfix_item = {
             filename = tag.file_path,
             lnum = tag.cursor and tag.cursor[1] or 1,

--- a/lua/grapple/tags.lua
+++ b/lua/grapple/tags.lua
@@ -122,6 +122,23 @@ function tags.reset(scope_)
 end
 
 ---@param scope_ Grapple.Scope
+function tags.quickfix(scope_)
+    local quickfix_items = {}
+    for tag_key, tag in pairs(_scoped_tags(scope_)) do
+        -- bufnr, filename, lnum, col, text
+        local quickfix_item = {
+            filename = tag.file_path,
+            lnum = tag.cursor and tag.cursor[1] or 1,
+            col = tag.cursor and tag.cursor[2] or 0,
+            text = string.format("[%s] %s", tag_key, tag.file_path),
+        }
+        table.insert(quickfix_items, quickfix_item)
+    end
+    vim.fn.setqflist(quickfix_items, "r")
+    vim.fn.setqflist({}, "a", { title = scope.get(scope_) })
+end
+
+---@param scope_ Grapple.Scope
 ---@param opts Grapple.Options
 function tags.tag(scope_, opts)
     local file_path

--- a/lua/grapple/tags.lua
+++ b/lua/grapple/tags.lua
@@ -136,6 +136,7 @@ function tags.quickfix(scope_)
     end
     vim.fn.setqflist(quickfix_items, "r")
     vim.fn.setqflist({}, "a", { title = scope.get(scope_) })
+    vim.api.nvim_cmd({ cmd = "copen" }, {})
 end
 
 ---@param scope_ Grapple.Scope

--- a/lua/grapple/tags.lua
+++ b/lua/grapple/tags.lua
@@ -129,8 +129,8 @@ function tags.quickfix(scope_)
         local quickfix_item = {
             filename = tag.file_path,
             lnum = tag.cursor and tag.cursor[1] or 1,
-            col = tag.cursor and tag.cursor[2] or 0,
-            text = string.format("[%s] %s", tag_key, tag.file_path),
+            col = tag.cursor and (tag.cursor[2] + 1) or 1,
+            text = string.format(" [%s] ", tag_key, tag.file_path),
         }
         table.insert(quickfix_items, quickfix_item)
     end

--- a/test/spec/grapple/tags_spec.lua
+++ b/test/spec/grapple/tags_spec.lua
@@ -1,0 +1,40 @@
+local scope = "none"
+local other_scope = "global"
+
+describe("tags", function()
+    before_each(function()
+        require("grapple.tags").reset(scope)
+        require("grapple.tags").reset(other_scope)
+    end)
+
+    after_each(function()
+        require("grapple.tags").reset(scope)
+        require("grapple.tags").reset(other_scope)
+    end)
+
+    describe("#quickfix", function()
+        it("populates the quickfix list for a given scope", function()
+            require("grapple.tags").tag(scope, { buffer = 0 })
+            require("grapple.tags").quickfix(scope)
+            assert.equals(1, vim.fn.getqflist({ size = 1 }).size)
+
+            local quickfix_list = vim.fn.getqflist()
+            assert.equals(0, quickfix_list[1].bufnr)
+            assert.equals(1, quickfix_list[1].lnum)
+            assert.equals(1, quickfix_list[1].col)
+            assert.equals(" [1] ", quickfix_list[1].text)
+        end)
+
+        it("does not populate the quickfix list with other scope tags", function()
+            require("grapple.tags").tag(other_scope, { buffer = 0 })
+            require("grapple.tags").quickfix(scope)
+            assert.equals(0, vim.fn.getqflist({ size = 1 }).size)
+        end)
+
+        it("opens the quickfix list", function()
+            require("grapple.tags").tag(scope, { buffer = 0 })
+            require("grapple.tags").quickfix(scope)
+            assert.not_equals(0, vim.fn.getqflist({ qfbufnr = 1 }).qfbufnr)
+        end)
+    end)
+end)


### PR DESCRIPTION
### Changes

* Add `grapple#quickfix` to open a tag scope's tags in the quickfix menu
* Add a `<c-q>` binding (similar to telescope) to go directly from the popup menu to the quickfix menu
* Add spec tests for `grapple.tags#quickfix`