### PR TITLE
fix(tags): open tag using relative file path

### DIFF
--- a/lua/grapple/tags.lua
+++ b/lua/grapple/tags.lua
@@ -183,7 +183,7 @@ function tags.select(tag)
         log.warn("Tagged file does not exist.")
     end
 
-    vim.api.nvim_cmd({ cmd = "edit", args = { tag.file_path } }, {})
+    vim.api.nvim_cmd({ cmd = "edit", args = { vim.fn.fnamemodify(tag.file_path, ":~:.") } }, {})
     if tag.cursor then
         vim.api.nvim_win_set_cursor(0, tag.cursor)
     end

--- a/lua/grapple/tags.lua
+++ b/lua/grapple/tags.lua
@@ -183,7 +183,7 @@ function tags.select(tag)
         log.warn("Tagged file does not exist.")
     end
 
-    vim.api.nvim_cmd({ cmd = "edit", args = { vim.fn.fnamemodify(tag.file_path, ":~:.") } }, {})
+    vim.api.nvim_cmd({ cmd = "edit", args = { Path:new(tag.file_path):make_relative() } }, {})
     if tag.cursor then
         vim.api.nvim_win_set_cursor(0, tag.cursor)
     end


### PR DESCRIPTION
Currently grapple opens files using their absolute path. The issue is that this creates inconsistent messages when writing to the file or hitting <c-g> to display the path. 

When the file is first tagged, this is the message that is shown:
<img width="381" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/56745535/8255e46f-574f-4402-a488-81a333ba7a24">. 

However, opening the file via Grapple results in the following:
<img width="595" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/56745535/56b584fb-d85a-447b-a7a9-13c42411aa4f">

This PR makes it so that the relative file path is used when opening a tagged file, unless the file is not within the current working directory, in which case the absolute file path is used. 