### PR TITLE
feat: add option to set popup tags window title via callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ The **tags popup menu** opens a floating window containing all the tags within a
 * **Quickfix (`<c-q>`)**: all tags will be [sent to the quickfix list](#grapplequickfix), the popup menu closed, and the quickfix menu opened
 * **Split (`<c-v>`)**: similar to tag selection, but the tagged file opened in a vertical split
 
-By default, the popup menu title is set to match the corresponding scope. However, you also have the flexibility to customize the tags popup menu title using a callback function. This custom title can be tailored to suit your specific preferences and doesn't necessarily need to correlate directly with the scope. Below, are some examples illustrating the possibilities:
+By default, the popup menu title is set to match the corresponding scope. However, you also have the flexibility to customize it using a callback function that receives the resolved form of the default scope as an optional argument. This custom title can be tailored to suit your specific preferences and doesn't need to correlate directly with the scope. Below, are some examples illustrating the possibilities:
 
 ```lua
 -- Set the title to "Grapple"
@@ -764,6 +764,13 @@ require("grapple").setup({
     popup_tags_title = function()
       local resolved_path = require("grapple.state").ensure_loaded(require("grapple.scope_resolvers").git)
       return resolved_path:gsub(vim.env.HOME, "~")
+    end,
+})
+
+-- Alternatively, you can modify the resolved default scope
+require("grapple").setup({
+    popup_tags_title = function(scope)
+      return string.format(" %s ", scope:gsub(vim.env.HOME, "~"))
     end,
 })
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ require("grapple").setup({
     ---@type string
     save_path = tostring(Path:new(vim.fn.stdpath("data")) / "grapple"),
 
+    --- A callback function that returns the popup tags window title
+    ---@type nil | fun(): string | nil
+    popup_tags_title = nil,
+
     ---Window options used for the popup menu
     popup_options = {
         relative = "editor",
@@ -746,6 +750,23 @@ The **tags popup menu** opens a floating window containing all the tags within a
 * **Renaming**: a [named tag](#named-tags) can be renamed by editing its key value between the `[` square brackets `]`
 * **Quickfix (`<c-q>`)**: all tags will be [sent to the quickfix list](#grapplequickfix), the popup menu closed, and the quickfix menu opened
 * **Split (`<c-v>`)**: similar to tag selection, but the tagged file opened in a vertical split
+
+By default, the popup menu title is set to match the corresponding scope. However, you also have the flexibility to customize the tags popup menu title using a callback function. This custom title can be tailored to suit your specific preferences and doesn't necessarily need to correlate directly with the scope. Below, are some examples illustrating the possibilities:
+
+```lua
+-- Set the title to "Grapple"
+require("grapple").setup({
+    popup_tags_title = function() return "Grapple" end
+})
+
+-- Set the title to the git root directory, with "~" substituted for $HOME
+require("grapple").setup({
+    popup_tags_title = function()
+      local resolved_path = require("grapple.state").ensure_loaded(require("grapple.scope_resolvers").git)
+      return resolved_path:gsub(vim.env.HOME, "~")
+    end,
+})
+```
 
 **Command**: `:GrapplePopup tags`
 

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -146,7 +146,7 @@ function grapple.popup_tags(scope)
 
     local window_options = vim.deepcopy(settings.popup_options)
     if vim.fn.has("nvim-0.9") == 1 then
-        window_options.title = popup_state.scope
+        window_options.title = settings.popup_tags_title and settings.popup_tags_title() or popup_state.scope
     end
 
     local popup = require("grapple.popup")

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -171,7 +171,7 @@ function grapple.popup_scopes()
 
     local window_options = vim.deepcopy(settings.popup_options)
     if vim.fn.has("nvim-0.9") == 1 then
-        window_options.title = "Loaded Scopes"
+        window_options.title = " Loaded Scopes "
     end
 
     local popup = require("grapple.popup")

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -146,8 +146,11 @@ function grapple.popup_tags(scope)
 
     local window_options = vim.deepcopy(settings.popup_options)
     if vim.fn.has("nvim-0.9") == 1 then
-        window_options.title = settings.popup_tags_title and settings.popup_tags_title()
-            or string.format(" %s ", popup_state.scope)
+        if type(settings.popup_tags_title) == "function" then
+            window_options.title = settings.popup_tags_title(popup_state.scope)
+        else
+            window_options.title = string.format(" %s ", popup_state.scope)
+        end
     end
 
     local popup = require("grapple.popup")

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -146,7 +146,8 @@ function grapple.popup_tags(scope)
 
     local window_options = vim.deepcopy(settings.popup_options)
     if vim.fn.has("nvim-0.9") == 1 then
-        window_options.title = settings.popup_tags_title and settings.popup_tags_title() or popup_state.scope
+        window_options.title = settings.popup_tags_title and settings.popup_tags_title()
+            or string.format(" %s ", popup_state.scope)
     end
 
     local popup = require("grapple.popup")

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -17,6 +17,10 @@ local DEFAULT_SETTINGS = {
     ---@type string
     save_path = tostring(Path:new(vim.fn.stdpath("data")) / "grapple"),
 
+    --- A callback function that returns the popup tags window title
+    ---@type nil | fun(): string | nil
+    popup_tags_title = nil,
+
     ---Window options used for the popup menu
     popup_options = {
         relative = "editor",

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -18,7 +18,7 @@ local DEFAULT_SETTINGS = {
     save_path = tostring(Path:new(vim.fn.stdpath("data")) / "grapple"),
 
     --- A callback function that returns the popup tags window title
-    ---@type nil | fun(): string | nil
+    ---@type nil | fun(string): string | nil
     popup_tags_title = nil,
 
     ---Window options used for the popup menu


### PR DESCRIPTION
This PR adds the option to set a custom title for the popup tags window via a callback function. It also adds padding between the left and right side of the default title to improve its appearance.

**Title set to " Grapple "**
<img width="913" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/56745535/a3fdd806-c6f3-4553-9662-d3f3ed4f049f">

<details>
<summary>Example config for resession.nvim</summary>

      local scope = require "grapple.scope"
      local resession = require "resession"
      local files = require "resession.files"
      local util = require "resession.util"

      local get_session_path = function(session_name)
        if session_name then
          local filename = util.get_session_file(session_name)
          local data = files.load_json_file(filename)
          local formatted = ""
          if data then
            if data.tab_scoped then
              local tab_cwd = data.tabs[1].cwd
              formatted = formatted .. string.format("%s (tab)", tab_cwd)
            else
              formatted = formatted .. string.format("%s", data.global.cwd)
            end
          end
          return formatted
        end
      end

      local session_path = scope.resolver(
        function() return string.format("%s", get_session_path(resession.get_current())) end,
        { cache = false, persist = false }
      )

      local session_name = scope.resolver(
        function() return string.format("%s", resession.get_current() or "No Session") end,
        { cache = false, persist = false }
      )

      local resolver =
        scope.fallback { scope.suffix(session_path, session_name, { persist = false }), require("grapple.scope_resolvers").git }

      local format_title = function()
        local current_session = resession.get_current()
        if current_session then return string.format(" %s [%s] ", current_session, util.shorten_path(get_session_path(current_session))) end
        return nil
      end

      require("grapple").setup {
        scope = resolver,
        popup_tags_title = format_title,
        popup_options = {
          border = "rounded",
        },
        integrations = {
          resession = true,
        },
      }


</details>

<img width="910" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/56745535/955c0a7b-7630-4653-9aa7-8be0206fb86f">
