### PR TITLE
fix(state): ensure default scope_resolver is stored in metatable when loading from resession

### DIFF
--- a/lua/grapple/state.lua
+++ b/lua/grapple/state.lua
@@ -292,6 +292,7 @@ function state.load_all(state_, opts)
         if getmetatable(scope_state) == nil then
             setmetatable(scope_state, {
                 __persist = opts.persist,
+                __resolver = settings.scope,
             })
         end
     end

--- a/lua/grapple/state.lua
+++ b/lua/grapple/state.lua
@@ -288,23 +288,19 @@ function state.state()
 end
 
 ---@param state_
----@param opts? { persist?: boolean }
+---@param opts? { persist?: boolean, resolver?: boolean }
 function state.load_all(state_, opts)
-    -- BUG: ensure_loaded is called before load_all, which then resets internal state
-    opts = opts or { persist = false }
+    opts = vim.tbl_extend("force", { persist = false, resolver = settings.scope }, opts or {})
 
     internal_state = state_
-    -- __AUTO_GENERATED_PRINT_VAR_START__
-    -- print("state.load_all internal_state:", vim.inspect(internal_state)) -- __AUTO_GENERATED_PRINT_VAR_END__
     for _, scope_state in pairs(internal_state) do
         if getmetatable(scope_state) == nil then
             setmetatable(scope_state, {
                 __persist = opts.persist,
-                __resolver = settings.scope,
+                __resolver = opts.resolver,
             })
         end
     end
-    vim.print("state.load_all internal state after: ", internal_state)
 end
 
 ---@param scope_? Grapple.Scope

--- a/lua/grapple/state.lua
+++ b/lua/grapple/state.lua
@@ -151,22 +151,7 @@ function state.ensure_loaded(scope_resolver)
     scope_resolver = scope.find_resolver(scope_resolver)
     local scope_ = scope.get(scope_resolver)
 
-    if internal_state[scope_] ~= nil then
-        -- NOTE: make it so that the scope_resolver passed into ensure_loaded overrides the existing one stored in the metatable
-        local scope_state = internal_state[scope_]
-        internal_state[scope_] = with_metatable(scope_state, scope_resolver)
-        -- __AUTO_GENERATED_PRINT_VAR_START__
-        -- print("state.ensure_loaded internal_state:", vim.inspect(internal_state)) -- __AUTO_GENERATED_PRINT_VAR_END__
-        return scope_
-    end
-
-    local scope_state
-    if scope_resolver.persist then
-        scope_state = state.load(scope_)
-    end
-    if scope_state == nil then
-        scope_state = {}
-    end
+    local scope_state = internal_state[scope_] or (scope_resolver.persist and state.load(scope_)) or {}
     internal_state[scope_] = with_metatable(scope_state, scope_resolver)
 
     return scope_
@@ -306,7 +291,6 @@ end
 ---@param scope_? Grapple.Scope
 function state.reset(scope_)
     if scope_ ~= nil then
-        -- BUG: scope_resolver is nil for some reason
         local scope_resolver = state.resolver(scope_)
         internal_state[scope_] = with_metatable({}, scope_resolver)
     else


### PR DESCRIPTION
Currently, resession integration is a bit incomplete since the `state.load_all` function does not set the __resolver metadata in the `scope_state` metatables. This causes nil index errors when trying to call `require("grapple").reset()`. 

1. The solution implemented here allows for an optional scope_resolver (which defaults to `settings.scope` to be passed into `load_all`, which is then used to set all the `__resolver` metadata. This ensures that the `__resolver` metadata is set, avoiding the nil index errors.

2. I also changed the behavior of `ensure_loaded` so that it always overrides and sets the `__resolver` metadata. Before, it would just return and do nothing if the `scope_state` was not empty, which intuitively doesn't really make much since because it isn't really "ensuring" that the scope_resolver is always being set. This alone is actually sufficient to fix the resession integration issues, but I still think the changes made in 1) are reasonable (though not really necessary).

A brief comment: I'm not sure if this project is still being maintained or if you'll ever read this, but on the off chance you do, I just wanted to thank you for all the hard work you've put into grapple. I truly think it's the best at what it does despite being heavily underrated (though I do know many people who prefer using it over harpoon). Your dedication to this project shows in its quality, and I along with many people are truly grateful for this amazing plugin you've contributed. Thanks!