### PR TITLE
feat(state): add `unload` functionionality

### DIFF
--- a/lua/grapple/popup_scopes.lua
+++ b/lua/grapple/popup_scopes.lua
@@ -44,7 +44,7 @@ function popup_scopes.resolve_differences(original_scopes, modified_scopes)
     -- Reset scopes that were removed from the popup menu
     for _, scope in ipairs(original_scopes) do
         if not scope_lookup[scope] then
-            state.reset(scope)
+            state.reset(scope, true)
         end
     end
 end

--- a/lua/grapple/state.lua
+++ b/lua/grapple/state.lua
@@ -297,16 +297,16 @@ function state.load_all(state_, opts)
     end
 end
 
----@param scope_ Grapple.Scope
-function state.unload(scope_)
-    internal_state[scope_] = nil
-end
-
 ---@param scope_? Grapple.Scope
-function state.reset(scope_)
+---@param unload? boolean
+function state.reset(scope_, unload)
     if scope_ ~= nil then
-        local scope_resolver = state.resolver(scope_)
-        internal_state[scope_] = with_metatable({}, scope_resolver)
+        if unload then
+            internal_state[scope_] = nil
+        else
+            local scope_resolver = state.resolver(scope_)
+            internal_state[scope_] = with_metatable({}, scope_resolver)
+        end
     else
         internal_state = {}
     end

--- a/lua/grapple/state.lua
+++ b/lua/grapple/state.lua
@@ -297,6 +297,11 @@ function state.load_all(state_, opts)
     end
 end
 
+---@param scope_ Grapple.Scope
+function state.unload(scope_)
+    internal_state[scope_] = nil
+end
+
 ---@param scope_? Grapple.Scope
 function state.reset(scope_)
     if scope_ ~= nil then


### PR DESCRIPTION
I have a custom scope resolver that I use with `resession.nvim` that returns the directory associated with the session, otherwise it uses the default "git" resolver as a fallback. 

Having an unload function is useful for removing all inactive scopes when creating a new session:
```lua
require("resession").add_hook("pre_save", function()
  local grapple_state = require("grapple.state").state()
  for loaded_scope, _ in pairs(grapple_state) do
    if loaded_scope ~= get_session_path(resession.get_current()) then require("grapple.state").reset(loaded_scope, true) end
  end
end)
```