### PR TITLE
fix: don't call `ensure_loaded()` for `grapple.find()` or `grapple.get()`

### DIFF
--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -68,7 +68,7 @@ end
 function grapple.find(opts)
     opts = vim.tbl_extend("force", { buffer = 0 }, opts or {})
 
-    local scope = require("grapple.state").ensure_loaded(opts.scope or settings.scope)
+    local scope = require("grapple.scope").get(opts.scope or settings.scope)
     return require("grapple.tags").find(scope, opts)
 end
 
@@ -76,7 +76,7 @@ end
 function grapple.key(opts)
     opts = vim.tbl_extend("force", { buffer = 0 }, opts or {})
 
-    local scope = require("grapple.state").ensure_loaded(opts.scope or settings.scope)
+    local scope = require("grapple.scope").get(opts.scope or settings.scope)
     return require("grapple.tags").key(scope, opts)
 end
 


### PR DESCRIPTION
Statusline integration typically relies on `grapple.find`, but this often means that `ensure_loaded()` is called excessively. I don't really see any benefit to having this included here, especially when you consider the performance hit that occurs as a result of the massive number of calls made.