### PR TITLE
feat: Grapple window status highlights

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: stylua-github
   - repo: https://github.com/lunarmodules/luacheck
-    rev: v1.0.0
+    rev: v1.1.2
     hooks:
       - id: luacheck
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: v0.20.0
     hooks:
       - id: stylua-github
-  - repo: https://github.com/lunarmodules/luacheck
-    rev: v1.1.2
-    hooks:
-      - id: luacheck
+  # - repo: https://github.com/lunarmodules/luacheck
+  #   rev: v1.1.2
+  #   hooks:
+  #     - id: luacheck
 
 files: "lua/.*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/JohnnyMorganz/StyLua
-    rev: v0.15.0
+    rev: v0.20.0
     hooks:
       - id: stylua-github
   - repo: https://github.com/lunarmodules/luacheck
@@ -8,4 +8,4 @@ repos:
     hooks:
       - id: luacheck
 
-files: 'lua/.*'
+files: "lua/.*"

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -461,8 +461,13 @@ end
 ---Initialize Grapple. Sets up autocommands to watch tagged files and creates the
 ---"Grapple" user command. Called only once when plugin is loaded.
 function Grapple.initialize()
-    vim.api.nvim_create_augroup("Grapple", { clear = true })
+    -- Create highlights for Grapple windows
+    vim.cmd.highlight({ "default", "link", "GrappleCurrent", "SpecialChar" })
+    vim.cmd.highlight({ "default", "link", "GrappleNoExist", "DiagnosticError" })
+    vim.cmd.highlight({ "default", "link", "GrappleEmpty", "DiagnosticInfo" })
 
+    -- Create autocommand to keep Grapple state up-to-date
+    vim.api.nvim_create_augroup("Grapple", { clear = true })
     vim.api.nvim_create_autocmd({ "BufWinLeave", "QuitPre" }, {
         pattern = "?*", -- non-empty file
         group = "Grapple",
@@ -473,6 +478,7 @@ function Grapple.initialize()
         end,
     })
 
+    -- Create top-level user command
     vim.api.nvim_create_user_command(
         "Grapple",
 

--- a/lua/grapple/container_content.lua
+++ b/lua/grapple/container_content.lua
@@ -36,13 +36,11 @@ end
 ---@param window grapple.window
 ---@return string? error
 function ContainerContent:attach(window)
-    if not self.hook_fn then
-        return
-    end
-
-    local err = self.hook_fn(window)
-    if err then
-        return err
+    if self.hook_fn then
+        local err = self.hook_fn(window)
+        if err then
+            return err
+        end
     end
 
     return nil
@@ -97,6 +95,9 @@ end
 ---@param index integer
 ---@return grapple.window.entry
 function ContainerContent:create_entry(entity, index)
+    local App = require("grapple.app")
+    local app = App.get()
+
     local container = entity.container
 
     -- A string representation of the index
@@ -107,14 +108,9 @@ function ContainerContent:create_entry(entity, index)
     local line = string.format("%s %s", id, rel_id)
     local min_col = assert(string.find(line, "%s")) -- width of id
 
-    local line_highlight
-    if entity.current then
-        line_highlight = {
-            hl_group = "GrappleCurrent",
-            line = index - 1,
-            col_start = min_col,
-            col_end = -1,
-        }
+    local sign_highlight
+    if app.settings.status and entity.current then
+        sign_highlight = "GrappleCurrent"
     end
 
     ---@type grapple.window.entry
@@ -129,7 +125,7 @@ function ContainerContent:create_entry(entity, index)
         min_col = min_col,
 
         ---@type grapple.vim.highlight[]
-        highlights = { line_highlight },
+        highlights = {},
 
         ---@type grapple.vim.extmark
         mark = {
@@ -137,6 +133,7 @@ function ContainerContent:create_entry(entity, index)
             col = 0,
             opts = {
                 sign_text = string.format("%d", index),
+                sign_hl_group = sign_highlight,
 
                 -- TODO: requires nvim-0.10
                 -- invalidate = true,

--- a/lua/grapple/path.lua
+++ b/lua/grapple/path.lua
@@ -389,7 +389,8 @@ end
 ---@param path string
 ---@return boolean
 function Path.is_uri(path)
-    local index = string.find(path, ":")
+    -- URIs can be more complex than this. Just use a basic check right now
+    local index = string.find(path, "://")
 
     -- 1. If there is no index, it is not a URI
     -- 2. If there is an index, check that it is not a Windows volume "C:"

--- a/lua/grapple/scope_content.lua
+++ b/lua/grapple/scope_content.lua
@@ -88,6 +88,9 @@ end
 ---@param index integer
 ---@return grapple.window.entry
 function ScopeContent:create_entry(entity, index)
+    local App = require("grapple.app")
+    local app = App.get()
+
     local scope = entity.scope
 
     -- A string representation of the index
@@ -97,14 +100,9 @@ function ScopeContent:create_entry(entity, index)
     local line = string.format("%s %s %s", id, scope.name, scope.desc)
     local min_col = assert(string.find(line, "%s")) -- width of id
 
-    local line_highlight
-    if entity.current then
-        line_highlight = {
-            hl_group = "GrappleCurrent",
-            line = index - 1,
-            col_start = min_col,
-            col_end = -1,
-        }
+    local sign_highlight
+    if app.settings.status and entity.current then
+        sign_highlight = "GrappleCurrent"
     end
 
     ---@type grapple.window.entry
@@ -119,7 +117,7 @@ function ScopeContent:create_entry(entity, index)
         min_col = min_col,
 
         ---@type grapple.vim.highlight[]
-        highlights = { line_highlight },
+        highlights = {},
 
         ---@type grapple.vim.extmark
         mark = {
@@ -127,6 +125,7 @@ function ScopeContent:create_entry(entity, index)
             col = 0,
             opts = {
                 sign_text = string.format("%d", index),
+                sign_hl_group = sign_highlight,
 
                 -- TODO: requires nvim-0.10
                 -- invalidate = true,

--- a/lua/grapple/scope_content.lua
+++ b/lua/grapple/scope_content.lua
@@ -34,13 +34,11 @@ end
 ---@param window grapple.window
 ---@return string? error
 function ScopeContent:attach(window)
-    if not self.hook_fn then
-        return
-    end
-
-    local err = self.hook_fn(window)
-    if err then
-        return err
+    if self.hook_fn then
+        local err = self.hook_fn(window)
+        if err then
+            return err
+        end
     end
 
     return nil
@@ -59,6 +57,9 @@ function ScopeContent:sync(original, parsed) end
 
 ---@return grapple.window.entity[] | nil, string? error
 function ScopeContent:entities()
+    local App = require("grapple.app")
+    local app = App.get()
+
     ---@param scope_a grapple.scope
     ---@param scope_b grapple.scope
     local function by_name(scope_a, scope_b)
@@ -68,19 +69,43 @@ function ScopeContent:entities()
     local scopes = vim.tbl_values(self.scope_manager.scopes)
     table.sort(scopes, by_name)
 
-    return scopes, nil
+    local entities = {}
+
+    for _, scope in ipairs(scopes) do
+        ---@class grapple.scope_content.entity
+        local entity = {
+            scope = scope,
+            current = scope.name == app.settings.scope,
+        }
+
+        table.insert(entities, entity)
+    end
+
+    return entities, nil
 end
 
----@param scope grapple.scope
+---@param entity grapple.scope_content.entity
 ---@param index integer
 ---@return grapple.window.entry
-function ScopeContent:create_entry(scope, index)
+function ScopeContent:create_entry(entity, index)
+    local scope = entity.scope
+
     -- A string representation of the index
     local id = string.format("/%03d", index)
 
     -- In compliance with "grapple" syntax
     local line = string.format("%s %s %s", id, scope.name, scope.desc)
     local min_col = assert(string.find(line, "%s")) -- width of id
+
+    local line_highlight
+    if entity.current then
+        line_highlight = {
+            hl_group = "GrappleCurrent",
+            line = index - 1,
+            col_start = min_col,
+            col_end = -1,
+        }
+    end
 
     ---@type grapple.window.entry
     local entry = {
@@ -94,7 +119,7 @@ function ScopeContent:create_entry(scope, index)
         min_col = min_col,
 
         ---@type grapple.vim.highlight[]
-        highlights = {},
+        highlights = { line_highlight },
 
         ---@type grapple.vim.extmark
         mark = {

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -12,9 +12,10 @@ local DEFAULT_SETTINGS = {
     ---@type boolean
     icons = true,
 
-    ---Add highlights to Grapple windows
+    ---Highlight the current selection in Grapple windows
+    ---Also, indicates when a tag path does not exist
     ---@type boolean
-    highlights = true,
+    status = true,
 
     ---Default scope to use when managing Grapple tags
     ---@type string
@@ -65,7 +66,7 @@ local DEFAULT_SETTINGS = {
             fallback = "cwd",
             cache = {
                 event = { "BufEnter", "FocusGained" },
-                debounce = 250, -- ms
+                debounce = 1000, -- ms
             },
             resolver = function()
                 -- TODO: this will stop on submodules, needs fixing
@@ -116,7 +117,8 @@ local DEFAULT_SETTINGS = {
                 debounce = 250, -- ms
             },
             resolver = function()
-                local clients = vim.lsp.get_clients({ bufnr = 0 })
+                -- TODO: Don't use vim.lsp.get_clients, it's a nvim-0.10 feature
+                local clients = vim.lsp.get_active_clients({ bufnr = 0 })
                 if #clients == 0 then
                     return
                 end

--- a/lua/grapple/tag_container.lua
+++ b/lua/grapple/tag_container.lua
@@ -139,6 +139,8 @@ function TagContainer:has(opts)
     -- stylua: ignore
 end
 
+---Get a tag by index, name, or path
+-- Guaranteed lookup order: index, then name, then path
 ---@param opts grapple.options
 ---@return grapple.tag | nil
 function TagContainer:get(opts)

--- a/lua/grapple/window.lua
+++ b/lua/grapple/window.lua
@@ -31,6 +31,7 @@ function Window:new(win_opts)
         au_id = WINDOW_GROUP,
         buf_id = nil,
         win_id = nil,
+        alt_win = nil,
         win_opts = win_opts or {},
     }, self)
 end
@@ -119,6 +120,9 @@ function Window:open()
         return
     end
 
+    -- Store current window as the "alternate window"
+    self.alt_win = vim.api.nvim_get_current_win()
+
     -- Create temporary buffer
     self.buf_id = self:create_buffer()
 
@@ -146,6 +150,7 @@ function Window:close()
         vim.api.nvim_win_close(self.win_id, true)
         self.win_id = nil
         self.buf_id = nil
+        self.alt_win = nil
     end
 
     self.entries = nil
@@ -324,6 +329,13 @@ function Window:render()
     local win_opts = self:window_options()
     vim.api.nvim_win_set_config(self.win_id, win_opts)
 
+    -- Attach the content to the window
+    ---@diagnostic disable-next-line: redefined-local
+    local err = self.content:attach(self)
+    if err then
+        return err
+    end
+
     -- Update window entries
     local entities, err = self.content:entities()
     if not entities then
@@ -350,13 +362,6 @@ function Window:render()
 
     for _, mark in ipairs(vim.tbl_map(to_mark, self.entries)) do
         vim.api.nvim_buf_set_extmark(self.buf_id, self.ns_id, mark.line, mark.col, mark.opts)
-    end
-
-    -- Attach the content to the rendered buffer
-    ---@diagnostic disable-next-line: redefined-local
-    local err = self.content:attach(self)
-    if err then
-        return err
     end
 
     -- Prevent undo after content has been rendered. Set undolevels to -1 when
@@ -464,8 +469,8 @@ function Window:map(mode, lhs, rhs, opts)
     )
 end
 
----See :h vim.api.nvim_create_autocmd
 ---Safety: used only inside a callback hook when a window is open
+---See :h vim.api.nvim_create_autocmd
 ---@param event any
 ---@param opts vim.api.keyset.create_autocmd
 function Window:autocmd(event, opts)
@@ -495,7 +500,7 @@ function Window:perform(action, opts)
     end
 end
 
----Safety: used only when a buffer is available
+---Safety: used only inside a callback hook when a window is open
 ---@return grapple.window.parsed_entry
 function Window:current_entry()
     local current_line = self:current_line()
@@ -503,13 +508,14 @@ function Window:current_entry()
     return entry
 end
 
----Safety: used only when a buffer is available
+---Safety: used only inside a callback hook when a window is open
 ---@return string
 function Window:current_line()
     return vim.api.nvim_get_current_line()
 end
 
----Safety: used only when a buffer is available
+---Safety: used only inside a callback hook when a window is open
+---@return string[]
 function Window:lines()
     return vim.api.nvim_buf_get_lines(self.buf_id, 0, -1, true)
 end
@@ -518,6 +524,19 @@ end
 ---@return integer[]
 function Window:cursor()
     return vim.api.nvim_win_get_cursor(self.win_id)
+end
+
+---Safety: used only inside a callback hook when a window is open
+---Returns the buffer for the current window before opening the Grapple window
+---@return string | nil
+function Window:alternate_buffer()
+    -- It's possible that the alternate window is not valid after opening the
+    -- grapple window. For example, opening Grapple from Telescope
+    if not vim.api.nvim_win_is_valid(self.alt_win) then
+        return
+    end
+
+    return vim.api.nvim_win_get_buf(self.alt_win)
 end
 
 return Window

--- a/lua/grapple/window.lua
+++ b/lua/grapple/window.lua
@@ -1,3 +1,4 @@
+local Path = require("grapple.path")
 local Util = require("grapple.util")
 
 ---@class grapple.window
@@ -527,16 +528,24 @@ function Window:cursor()
 end
 
 ---Safety: used only inside a callback hook when a window is open
----Returns the buffer for the current window before opening the Grapple window
+---Returns the path for the buffer from current window before opening the
+---Grapple window. In a sense, it's like vim's alternate file
 ---@return string | nil
-function Window:alternate_buffer()
+function Window:alternate_path()
     -- It's possible that the alternate window is not valid after opening the
     -- grapple window. For example, opening Grapple from Telescope
     if not vim.api.nvim_win_is_valid(self.alt_win) then
         return
     end
 
-    return vim.api.nvim_win_get_buf(self.alt_win)
+    local alt_buf = vim.api.nvim_win_get_buf(self.alt_win)
+    local alt_name = vim.api.nvim_buf_get_name(alt_buf)
+
+    if alt_name == "" then
+        return
+    end
+
+    return Path.fs_absolute(alt_name)
 end
 
 return Window


### PR DESCRIPTION
### Context

Small highlights to indicate the current tag, scope, and loaded scope. Can be enabled or disabled with `settings.status`. Default is enabled (`status = true`).

<img width="1059" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/2467016/e1fda612-c4f2-4202-9264-c8c6aee68795">

<img width="1059" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/2467016/6af61cfa-3765-4dbf-a117-d599791e9a74">
