### PR TITLE
feat!: better window keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Popup windows are made available to enable easy management of tags and scopes. T
 Open a floating window with all the tags for a given scope. This buffer is modifiable. Several actions are available by default:
 
 - **Selection** (`<cr>`): select the tag under the cursor
-- **Split (horizontal)** (`<c-v>`): select the tag under the cursor (`split`)
+- **Split (horizontal)** (`<c-s>`): select the tag under the cursor (`split`)
 - **Split (vertical)** (`|`): select the tag under the cursor (`vsplit`)
 - **Quick select** (`1-9`): select the tag at a given index
 - **Deletion**: delete a line to delete the tag

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Open a floating window with all the tags for a given scope. This buffer is modif
 - **Deletion**: delete a line to delete the tag
 - **Reordering**: move a line to move a tag
 - **Quickfix** (`<c-q>`): send all tags to the quickfix list ([`:h quickfix`](https://neovim.io/doc/user/quickfix.html))
-- **Go up** (`-`): navigate "up" to the [scopes window](#scopes-window)
+- **Go up** (`-`): navigate up to the [scopes window](#scopes-window)
 
 **API**:
 
@@ -610,7 +610,7 @@ Open a floating window with all defined scopes. This buffer is not modifiable. S
 
 - **Selection** (`<cr>`): set the current scope to the one under the cursor
 - **Quick select** (`1-9`): select the scope at a given index
-- **Go up** (`-`): navigate "up" to the [loaded scopes window](#loaded-scopes-window)
+- **Go up** (`-`): navigate across to the [loaded scopes window](#loaded-scopes-window)
 
 **API**:
 
@@ -636,7 +636,7 @@ Open a floating window with all loaded scopes. This buffer is not modifiable. So
 - **Selection** (`<cr>`): open the tags window for the loaded scope under the cursor
 - **Quick select** (`1-9`): select the loaded scope at a given index
 - **Deletion (`x`)**: reset the tags for the loaded scope under the cursor
-- **Go up** (`-`): navigate "up" to the [scopes window](#scopes-window)
+- **Go up** (`-`): navigate across to the [scopes window](#scopes-window)
 
 **API**:
 

--- a/README.md
+++ b/README.md
@@ -571,12 +571,13 @@ Popup windows are made available to enable easy management of tags and scopes. T
 Open a floating window with all the tags for a given scope. This buffer is modifiable. Several actions are available by default:
 
 - **Selection** (`<cr>`): select the tag under the cursor
-- **Split (horizontal)** (`-`): select the tag under the cursor (`split`)
+- **Split (horizontal)** (`<c-v>`): select the tag under the cursor (`split`)
 - **Split (vertical)** (`|`): select the tag under the cursor (`vsplit`)
 - **Quick select** (`1-9`): select the tag at a given index
 - **Deletion**: delete a line to delete the tag
 - **Reordering**: move a line to move a tag
 - **Quickfix** (`<c-q>`): send all tags to the quickfix list ([`:h quickfix`](https://neovim.io/doc/user/quickfix.html))
+- **Go up** (`-`): navigate "up" to the [scopes window](#scopes-window)
 
 **API**:
 
@@ -608,6 +609,8 @@ require("grapple").open_tags("global")
 Open a floating window with all defined scopes. This buffer is not modifiable. Some basic actions are available by default:
 
 - **Selection** (`<cr>`): set the current scope to the one under the cursor
+- **Quick select** (`1-9`): select the scope at a given index
+- **Go up** (`-`): navigate "up" to the [loaded scopes window](#loaded-scopes-window)
 
 **API**:
 
@@ -631,7 +634,9 @@ require("grapple").open_scopes()
 Open a floating window with all loaded scopes. This buffer is not modifiable. Some basic actions are available by default:
 
 - **Selection** (`<cr>`): open the tags window for the loaded scope under the cursor
+- **Quick select** (`1-9`): select the loaded scope at a given index
 - **Deletion (`x`)**: reset the tags for the loaded scope under the cursor
+- **Go up** (`-`): navigate "up" to the [scopes window](#scopes-window)
 
 **API**:
 

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -390,6 +390,8 @@ function Grapple.use_scope(scope)
     end
 
     app.settings:update({ scope = resolved.name })
+
+    vim.notify(string.format("Changing scope: %s", resolved.name))
 end
 
 ---@param scope? string

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -389,9 +389,10 @@ function Grapple.use_scope(scope)
         return vim.notify(err, vim.log.levels.ERROR)
     end
 
-    app.settings:update({ scope = resolved.name })
-
-    vim.notify(string.format("Changing scope: %s", resolved.name))
+    if resolved.name ~= app.settings.scope then
+        app.settings:update({ scope = resolved.name })
+        vim.notify(string.format("Changing scope: %s", resolved.name))
+    end
 end
 
 ---@param scope? string

--- a/lua/grapple/container_actions.lua
+++ b/lua/grapple/container_actions.lua
@@ -6,15 +6,17 @@ local ContainerActions = {}
 ---@field id? string
 
 ---@param opts grapple.action.container_options
----@return string? error
 function ContainerActions.select(opts)
     require("grapple").open_tags({ id = opts.id })
 end
 
 ---@param opts grapple.action.container_options
----@return string? error
 function ContainerActions.reset(opts)
     require("grapple").reset({ id = opts.id })
+end
+
+function ContainerActions.open_scopes()
+    require("grapple").open_scopes()
 end
 
 return ContainerActions

--- a/lua/grapple/scope_actions.lua
+++ b/lua/grapple/scope_actions.lua
@@ -6,9 +6,13 @@ local ScopeActions = {}
 ---@field name? string
 
 ---@param opts grapple.action.scope_options
----@return string? error
 function ScopeActions.select(opts)
     require("grapple").use_scope(opts.name)
+    require("grapple").open_tags()
+end
+
+function ScopeActions.open_loaded()
+    require("grapple").open_loaded()
 end
 
 return ScopeActions

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -182,7 +182,7 @@ local DEFAULT_SETTINGS = {
         -- Go "up" to scopes
         window:map("n", "-", function()
             window:perform(TagActions.open_scopes)
-        end)
+        end, { desc = "Go to scopes" })
     end,
 
     ---User-defined scopes title function for Grapple windows
@@ -267,7 +267,7 @@ local DEFAULT_SETTINGS = {
         -- Navigate "up" to scopes
         window:map("n", "-", function()
             window:perform(ContainerActions.open_scopes)
-        end)
+        end, { desc = "Go to scopes" })
     end,
 
     ---Additional window options for Grapple windows

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -156,7 +156,7 @@ local DEFAULT_SETTINGS = {
         end, { desc = "Select" })
 
         -- Select (horizontal split)
-        window:map("n", "<c-v>", function()
+        window:map("n", "<c-s>", function()
             local cursor = window:cursor()
             window:perform(TagActions.select, { index = cursor[1], command = vim.cmd.split })
         end, { desc = "Select (split)" })

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -202,7 +202,6 @@ local DEFAULT_SETTINGS = {
             local entry = window:current_entry()
             local name = entry.data.name
             window:perform(ScopeActions.select, { name = name })
-            vim.notify(string.format("Changing scope: %s", name))
         end, { desc = "Change scope" })
 
         -- Quick select

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -152,54 +152,37 @@ local DEFAULT_SETTINGS = {
         -- Select
         window:map("n", "<cr>", function()
             local cursor = window:cursor()
-            local err = window:perform(TagActions.select, { index = cursor[1] })
-            if err then
-                vim.notify(err, vim.log.levels.ERROR)
-            end
+            window:perform(TagActions.select, { index = cursor[1] })
         end, { desc = "Select" })
 
         -- Select (horizontal split)
-        window:map("n", "-", function()
+        window:map("n", "<c-v>", function()
             local cursor = window:cursor()
-            local err = window:perform(TagActions.select, { index = cursor[1], command = vim.cmd.split })
-            if err then
-                vim.notify(err, vim.log.levels.ERROR)
-            end
+            window:perform(TagActions.select, { index = cursor[1], command = vim.cmd.split })
         end, { desc = "Select (split)" })
 
         -- Select (vertical split)
         window:map("n", "|", function()
             local cursor = window:cursor()
-            local err = window:perform(TagActions.select, { index = cursor[1], command = vim.cmd.vsplit })
-            if err then
-                vim.notify(err, vim.log.levels.ERROR)
-            end
+            window:perform(TagActions.select, { index = cursor[1], command = vim.cmd.vsplit })
         end, { desc = "Select (vsplit)" })
 
         -- Quick select
         for i = 1, 9 do
             window:map("n", string.format("%s", i), function()
-                local err = window:perform(TagActions.select, { index = i })
-                if err then
-                    vim.notify(err, vim.log.levels.ERROR)
-                end
+                window:perform(TagActions.select, { index = i })
             end, { desc = string.format("Select %d", i) })
         end
 
         -- Quickfix list
         window:map("n", "<c-q>", function()
-            local err = window:perform(TagActions.quickfix)
-            if err then
-                vim.notify(err, vim.log.levels.ERROR)
-            end
+            window:perform(TagActions.quickfix)
         end, { desc = "Quickfix" })
 
-        window:map("n", "<c-r>", function()
-            local err = window:refresh()
-            if err then
-                vim.notify(err, vim.log.levels.ERROR)
-            end
-        end, { desc = "Refresh" })
+        -- Go "up" to scopes
+        window:map("n", "-", function()
+            window:perform(TagActions.open_scopes)
+        end)
     end,
 
     ---User-defined scopes title function for Grapple windows
@@ -214,17 +197,32 @@ local DEFAULT_SETTINGS = {
     scope_hook = function(window)
         local ScopeActions = require("grapple.scope_actions")
 
+        -- Select
         window:map("n", "<cr>", function()
             local entry = window:current_entry()
             local name = entry.data.name
-
-            local err = window:perform(ScopeActions.select, { name = name })
-            if err then
-                return vim.notify(err, vim.log.levels.ERROR)
-            end
-
+            window:perform(ScopeActions.select, { name = name })
             vim.notify(string.format("Changing scope: %s", name))
         end, { desc = "Change scope" })
+
+        -- Quick select
+        for i = 1, 9 do
+            window:map("n", string.format("%s", i), function()
+                local entry, err = window:entry({ index = i })
+                if not entry then
+                    ---@diagnostic disable-next-line: param-type-mismatch
+                    return vim.notify(err, vim.log.levels.ERROR)
+                end
+
+                local name = entry.data.name
+                window:perform(ScopeActions.select, { name = name })
+            end, { desc = string.format("Select %d", i) })
+        end
+
+        -- Navigate "up" to loaded scopes
+        window:map("n", "-", function()
+            window:perform(ScopeActions.open_loaded)
+        end, { desc = "Go to loaded scopes" })
     end,
 
     ---User-defined loaded scopes title function for Grapple windows
@@ -239,27 +237,38 @@ local DEFAULT_SETTINGS = {
     loaded_hook = function(window)
         local ContainerActions = require("grapple.container_actions")
 
+        -- Select
         window:map("n", "<cr>", function()
             local entry = window:current_entry()
             local id = entry.data.id
-
-            local err = window:perform(ContainerActions.select, { id = id })
-            if err then
-                return vim.notify(err, vim.log.levels.ERROR)
-            end
+            window:perform(ContainerActions.select, { id = id })
         end, { desc = "Open tags" })
 
+        -- Quick select
+        for i = 1, 9 do
+            window:map("n", string.format("%s", i), function()
+                local entry, err = window:entry({ index = i })
+                if not entry then
+                    ---@diagnostic disable-next-line: param-type-mismatch
+                    return vim.notify(err, vim.log.levels.ERROR)
+                end
+
+                local name = entry and entry.data.name
+                window:perform(ContainerActions.select, { name = name })
+            end, { desc = string.format("Select %d", i) })
+        end
+
+        -- Reset
         window:map("n", "x", function()
             local entry = window:current_entry()
             local id = entry.data.id
-
-            local err = window:perform(ContainerActions.reset, { id = id })
-            if err then
-                return vim.notify(err, vim.log.levels.ERROR)
-            end
-
-            vim.notify(string.format("Reset scope: %s", id))
+            window:perform(ContainerActions.reset, { id = id })
         end, { desc = "Reset scope" })
+
+        -- Navigate "up" to scopes
+        window:map("n", "-", function()
+            window:perform(ContainerActions.open_scopes)
+        end)
     end,
 
     ---Additional window options for Grapple windows

--- a/lua/grapple/tag_actions.lua
+++ b/lua/grapple/tag_actions.lua
@@ -34,4 +34,8 @@ function TagActions.quickfix(opts)
     require("grapple").quickfix({ scope = opts.scope.name })
 end
 
+function TagActions.open_scopes()
+    require("grapple").open_scopes()
+end
+
 return TagActions

--- a/lua/grapple/window.lua
+++ b/lua/grapple/window.lua
@@ -502,11 +502,29 @@ function Window:perform(action, opts)
 end
 
 ---Safety: used only inside a callback hook when a window is open
+---Returns a parsed entry for the current line
 ---@return grapple.window.parsed_entry
 function Window:current_entry()
     local current_line = self:current_line()
     local entry = self.content:parse_line(current_line)
     return entry
+end
+
+---Safety: used only inside a callback hook when a window is open
+---Returns a parsed entry for a line at a given index
+---@param opts { index: integer }
+---@return grapple.window.parsed_entry | nil, string? error
+function Window:entry(opts)
+    local lines = self:lines()
+
+    local line = lines[opts.index]
+    if not line then
+        return nil, string.format("no entry for index: %s", opts.index)
+    end
+
+    local entry = self.content:parse_line(line)
+
+    return entry, nil
 end
 
 ---Safety: used only inside a callback hook when a window is open


### PR DESCRIPTION
### Context

Noticed some opportunity for improving moving between Grapple windows. In short, use the keymap `-` (like netrw) to navigate "up" or "across" to an parent or adjacent window. This allows users to seamlessly move from one window to another, making managing tags and scopes a breeze 🙂 In addition, added much-needed quick-select keymaps for each window.

### Breaking Changes

- **Changed** Split (horizontal) is now mapped (by default) to `<c-s>`

### Changes

- Tags Window
    - **Changed** Split (horizontal) is now mapped (by default) to `<c-s>`
    - **NEW** Navigate "up" to the Scopes window with `-`
- Scopes Window
    - **NEW** Quick select a scope (`1-9`)
    - **NEW** Navigate "across" to the Loaded Scopes window with `-`
- Loaded Scopes Window
    - **NEW** Quick select a loaded scope (`1-9`)
    - **NEW** Navigate "across" to the Scopes window with `-`

