### PR TITLE
feat: user command completion + default use "toggle"

### DIFF
--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -569,8 +569,9 @@ function Grapple.initialize()
                 -- "new" kwargs refer to methods that create a new tag (i.e. tag)
                 -- "use" kwargs refer to methods that use an existing tag (i.e. select)
                 -- "scope" kwargs refer to methods that operate on a scope (i.e. quickfix)
+                -- TODO: allow "cursor" as a string argument
                 local tag_kwargs = { "buffer", "path", "name", "index", "cursor", "scope", "command" }
-                local new_kwargs = Util.subtract(tag_kwargs, { "command" })
+                local new_kwargs = Util.subtract(tag_kwargs, { "cursor", "command" })
                 local use_kwargs = Util.subtract(tag_kwargs, { "cursor" })
                 local scope_kwargs = { "scope", "id" }
 

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -559,7 +559,7 @@ function Grapple.initialize()
         {
             desc = "Grapple",
             nargs = "*",
-            complete = function(current, command, index)
+            complete = function(current, command, _)
                 local Util = require("grapple.util")
                 local App = require("grapple.app")
                 local app = App.get()

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -596,7 +596,7 @@ function Grapple.initialize()
                     use_scope      = { args = { "scope" },     kwargs = {} },
                 }
 
-                -- Lookup table of known arguments and their known values
+                -- Lookup table of arguments and their known values
                 local argument_lookup = {
                     direction = { "forward", "backward" },
                     scope = Util.sort(vim.tbl_keys(app.scope_manager.scopes), Util.as_lower),

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -522,7 +522,7 @@ function Grapple.initialize()
         end,
     })
 
-    -- Create top-level user command
+    -- Create top-level user command. Basically a wrapper around the lua API
     vim.api.nvim_create_user_command(
         "Grapple",
 
@@ -564,9 +564,14 @@ function Grapple.initialize()
                 local App = require("grapple.app")
                 local app = App.get()
 
+                -- Keyword argument names permitted by Grapple
+                -- "tag" kwargs refer to methods that accept all keyword argument (i.e. toggle)
+                -- "new" kwargs refer to methods that create a new tag (i.e. tag)
+                -- "use" kwargs refer to methods that use an existing tag (i.e. select)
+                -- "scope" kwargs refer to methods that operate on a scope (i.e. quickfix)
                 local tag_kwargs = { "buffer", "path", "name", "index", "cursor", "scope", "command" }
-                local use_kwargs = Util.subtract(tag_kwargs, { "cursor" })
                 local new_kwargs = Util.subtract(tag_kwargs, { "command" })
+                local use_kwargs = Util.subtract(tag_kwargs, { "cursor" })
                 local scope_kwargs = { "scope", "id" }
 
                 -- stylua: ignore
@@ -597,7 +602,7 @@ function Grapple.initialize()
                     scope = Util.sort(vim.tbl_keys(app.scope_manager.scopes), Util.as_lower),
                 }
 
-                -- API functions which are not actionable
+                -- API methods which are not actionable
                 local excluded_subcmds = {
                     "define_scope",
                     "exists",

--- a/lua/grapple/path.lua
+++ b/lua/grapple/path.lua
@@ -119,7 +119,7 @@ function Path.clean(path)
     -- Expand upward-relative path operatives
     local dotdot = 0
     local path_parts = Util.reduce(
-        vim.tbl_filter(Util.is_empty, vim.split(path, Path.separator)),
+        vim.tbl_filter(Util.not_empty, vim.split(path, Path.separator)),
 
         ---@param parts string[]
         ---@param part string
@@ -271,8 +271,8 @@ function Path.relative(base, targ)
         return nil, string.format("cannot make %s relative to %s", base, targ)
     end
 
-    local base_parts = vim.tbl_filter(Util.is_empty, vim.split(base_path, Path.separator))
-    local targ_parts = vim.tbl_filter(Util.is_empty, vim.split(targ_path, Path.separator))
+    local base_parts = vim.tbl_filter(Util.not_empty, vim.split(base_path, Path.separator))
+    local targ_parts = vim.tbl_filter(Util.not_empty, vim.split(targ_path, Path.separator))
 
     local last_index = 1
     while Path.are_same(base_parts[last_index], targ_parts[last_index]) do

--- a/lua/grapple/util.lua
+++ b/lua/grapple/util.lua
@@ -16,16 +16,83 @@ function Util.reduce(list, fn, init)
     return acc
 end
 
-function Util.is_empty(value)
-    return value ~= ""
+---@generic T
+---@param tbl T[]
+---@param removed T[]
+---@return T[]
+function Util.subtract(tbl, removed)
+    local lookup = {}
+    for _, value in ipairs(removed) do
+        lookup[value] = true
+    end
+
+    local subtracted = vim.deepcopy(tbl)
+    for i = #subtracted, 0, -1 do
+        if lookup[subtracted[i]] then
+            table.remove(subtracted, i)
+        end
+    end
+
+    return subtracted
 end
 
-function Util.is_nil(value)
+---@generic T
+---@param list_a T[]
+---@param list_b T[]
+---@return boolean
+function Util.same(list_a, list_b)
+    if #list_a ~= #list_b then
+        return false
+    end
+
+    return #Util.subtract(list_a, list_b) == 0
+end
+
+---Transformer adds a prefix to a string value
+---@param prefix string
+---@return fun(value: string): string
+function Util.with_prefix(prefix)
+    return function(value)
+        return prefix .. value
+    end
+end
+
+---Transformer adds a suffix to a string value
+---@param suffix string
+---@return fun(value: string): string
+function Util.with_suffix(suffix)
+    return function(value)
+        return value .. suffix
+    end
+end
+
+---Predicate to return if a value is starts with a prefix
+---@param prefix string
+---@return fun(value: string): boolean
+function Util.startswith(prefix)
+    return function(value)
+        return vim.startswith(value, prefix)
+    end
+end
+
+---Predicate to return if a string value is not empty
+---@param value string
+---@return boolean
+function Util.not_empty(value)
+    return vim.trim(value) ~= ""
+end
+
+---Predicate to return if a value is not nil
+---@param value any
+---@return boolean
+function Util.not_nil(value)
     return value ~= nil
 end
 
-function Util.trim(value)
-    return vim.trim(value)
+---@param str_a string
+---@param str_b string
+function Util.as_lower(str_a, str_b)
+    return string.lower(str_a) < string.lower(str_b)
 end
 
 return Util

--- a/lua/grapple/util.lua
+++ b/lua/grapple/util.lua
@@ -1,5 +1,16 @@
 local Util = {}
 
+---Sorts list elements in a given order, *not-in-place*, from `list[1]` to `list[#list]`.
+---@generic T
+---@param list T[]
+---@param fn fun(a: T, b: T): boolean
+---@return T[]
+function Util.sort(list, fn)
+    list = vim.deepcopy(list)
+    table.sort(list, fn)
+    return list
+end
+
 ---@param list table
 ---@param fn fun(acc: any, value: any, index?: integer): any
 ---@param init any

--- a/lua/grapple/window.lua
+++ b/lua/grapple/window.lua
@@ -237,7 +237,7 @@ function Window:parse_lines()
     end
 
     ---@diagnostic disable: redefined-local
-    local lines = vim.tbl_filter(Util.is_empty, self:lines())
+    local lines = vim.tbl_filter(Util.not_empty, self:lines())
 
     ---@type grapple.window.parsed_entry[]
     local parsed_entries = {}


### PR DESCRIPTION
## Context

The `Grapple` user command is expected to be mostly a wrapper around the Lua API. For example,

```
Grapple cycle forward scope=git buffer=0
```

Should translate to 

```
require("grapple").cycle("forward", { scope = "git", buffer = 0 })
```

However, while this already works there is no user feedback. This PR adds a completion function to the user command to aid the user in writing a valid set of input arguments.

## Changes

- Command completion for `Grapple`
- `Grapple` defaults to using "toggle" when no arguments are provided

### Subcommand completion

<img width="1080" alt="Screenshot 2024-03-02 at 23 22 11" src="https://github.com/cbochs/grapple.nvim/assets/2467016/b8edd02b-ebd4-4397-897c-a9b11a5e26ea">

### Positional argument completion

<img width="1080" alt="Screenshot 2024-03-02 at 23 22 18" src="https://github.com/cbochs/grapple.nvim/assets/2467016/a1a3bfa8-b764-4c4f-bc57-a5cab7d7f5ec">

### Keyword argument key completion

<img width="1080" alt="Screenshot 2024-03-02 at 23 22 30" src="https://github.com/cbochs/grapple.nvim/assets/2467016/6a860dcd-79bb-458f-821f-5ba21056d8ff">

### Keyword argument value completion

<img width="1080" alt="Screenshot 2024-03-02 at 23 22 36" src="https://github.com/cbochs/grapple.nvim/assets/2467016/27fab6cc-b2a6-4a20-9fae-ee0f7830557e">

