### PR TITLE
feat!: use <s-cr> to change scope and <cr> to open tags in scopes window

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,8 +625,9 @@ require("grapple").open_tags("global")
 
 Open a floating window with all defined scopes. This buffer is not modifiable. Some basic actions are available by default:
 
-- **Selection** (`<cr>`): set the current scope to the one under the cursor
-- **Quick select** (`1-9`): select the scope at a given index
+- **Selection** (`<cr>`): open the [tags window](#tags-window) for the scope under the cursor
+- **Quick select** (`1-9`): open the tags window for the scope at a given index
+- **Change** (`<s-cr>`): change the current scope to the one under the cursor
 - **Go up** (`-`): navigate across to the [loaded scopes window](#loaded-scopes-window)
 
 **API**:
@@ -650,8 +651,8 @@ require("grapple").open_scopes()
 
 Open a floating window with all loaded scopes. This buffer is not modifiable. Some basic actions are available by default:
 
-- **Selection** (`<cr>`): open the tags window for the loaded scope under the cursor
-- **Quick select** (`1-9`): select the loaded scope at a given index
+- **Selection** (`<cr>`): open the [tags window](#tags-window) for the loaded scope under the cursor
+- **Quick select** (`1-9`): open tags window for the loaded scope at a given index
 - **Deletion (`x`)**: reset the tags for the loaded scope under the cursor
 - **Go up** (`-`): navigate across to the [scopes window](#scopes-window)
 

--- a/lua/grapple/scope_actions.lua
+++ b/lua/grapple/scope_actions.lua
@@ -6,9 +6,14 @@ local ScopeActions = {}
 ---@field name? string
 
 ---@param opts grapple.action.scope_options
-function ScopeActions.select(opts)
+function ScopeActions.change(opts)
     require("grapple").use_scope(opts.name)
     require("grapple").open_tags()
+end
+
+---@param opts grapple.action.scope_options
+function ScopeActions.open_tags(opts)
+    require("grapple").open_tags({ scope = opts.name })
 end
 
 function ScopeActions.open_loaded()

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -202,8 +202,8 @@ local DEFAULT_SETTINGS = {
         window:map("n", "<cr>", function()
             local entry = window:current_entry()
             local name = entry.data.name
-            window:perform(ScopeActions.select, { name = name })
-        end, { desc = "Change scope" })
+            window:perform(ScopeActions.open_tags, { name = name })
+        end, { desc = "Open scope" })
 
         -- Quick select
         for i = 1, 9 do
@@ -215,9 +215,16 @@ local DEFAULT_SETTINGS = {
                 end
 
                 local name = entry.data.name
-                window:perform(ScopeActions.select, { name = name })
-            end, { desc = string.format("Select %d", i) })
+                window:perform(ScopeActions.open_tags, { name = name })
+            end, { desc = string.format("Open %d", i) })
         end
+
+        -- Change
+        window:map("n", "<s-cr>", function()
+            local entry = window:current_entry()
+            local name = entry.data.name
+            window:perform(ScopeActions.change, { name = name })
+        end, { desc = "Change scope" })
 
         -- Navigate "up" to loaded scopes
         window:map("n", "-", function()


### PR DESCRIPTION
## Context

Found that changing to a different default scope is not typical, but using multiple scopes is very useful. Changed the default mappings to reflect this.

### Changes

**Scopes Window**
- Map `<s-cr>` to change the scope and open the tags window
- Map `<cr>` to only open the tags window and **not** change the scope