### PR TITLE
fix: improve window entry parsing

### DIFF
--- a/lua/grapple/path.lua
+++ b/lua/grapple/path.lua
@@ -309,11 +309,11 @@ end
 ---@param path string
 ---@return boolean
 function Path.is_joinable(path)
-    return vim.startswith(path, "./")
-        or vim.startswith(path, "../")
-        or vim.startswith(path, "~")
-        or Path.is_uri(path)
-        or Path.is_absolute(path)
+    return not vim.startswith(path, "./")
+        and not vim.startswith(path, "../")
+        and not vim.startswith(path, "~")
+        and not Path.is_uri(path)
+        and not Path.is_absolute(path)
 end
 
 ---@param ... string

--- a/lua/grapple/scope_content.lua
+++ b/lua/grapple/scope_content.lua
@@ -148,20 +148,18 @@ function ScopeContent:create_entry(entity, index)
     return entry
 end
 
+---Safety: assume that the content is unmodifiable and the ID
+---can always be parsed
 ---@param line string
+---@param original_entries grapple.window.entry[]
 ---@return grapple.window.parsed_entry
-function ScopeContent:parse_line(line)
-    local id, name = string.match(line, "^/(%d+) (%S*)")
-    local index = tonumber(id)
+function ScopeContent:parse_line(line, original_entries)
+    local id, _ = string.match(line, "^/(%d+) (%S+) %S+")
+    local index = assert(tonumber(id))
 
     ---@type grapple.window.parsed_entry
-    local entry = {
-        data = {
-            name = name,
-        },
-        index = index,
-        line = line,
-    }
+    ---@diagnostic disable-next-line: assign-type-mismatch
+    local entry = vim.deepcopy(original_entries[index])
 
     return entry
 end

--- a/lua/grapple/window.lua
+++ b/lua/grapple/window.lua
@@ -216,6 +216,7 @@ end
 ---@class grapple.window.parsed_entry
 ---@field data any
 ---@field line string
+---@field modified boolean
 ---@field index? integer
 ---@field min_col? integer
 ---@field highlights? grapple.vim.highlight[]
@@ -234,7 +235,7 @@ function Window:parse_lines()
     local parsed_entries = {}
 
     for _, line in ipairs(lines) do
-        local entry = self.content:parse_line(line)
+        local entry = self.content:parse_line(line, self.entries)
         table.insert(parsed_entries, entry)
     end
 
@@ -244,7 +245,7 @@ end
 ---@param line string
 ---@return integer min_col
 function Window:minimum_column(line)
-    local parsed_entry = self.content:parse_line(line)
+    local parsed_entry = self.content:parse_line(line, self.entries)
 
     local index = parsed_entry.index
     if not index then
@@ -497,7 +498,7 @@ end
 ---@return grapple.window.parsed_entry
 function Window:current_entry()
     local current_line = self:current_line()
-    local entry = self.content:parse_line(current_line)
+    local entry = self.content:parse_line(current_line, self.entries)
     return entry
 end
 
@@ -513,7 +514,7 @@ function Window:entry(opts)
         return nil, string.format("no entry for index: %s", opts.index)
     end
 
-    local entry = self.content:parse_line(line)
+    local entry = self.content:parse_line(line, self.entries)
 
     return entry, nil
 end


### PR DESCRIPTION
### Context

There were some issues with parsing the scope and loaded scope content windows. This should fix those few issues.

### Changes

- `Content.parse_line` now receives a list of original entries
- Parsed entries must now include whether it has been "modified" or not
- Path.is_joinable was performing the opposite logic
- Scope and Container content now make assumptions while parsing that the content is unmodifiable