### PR TITLE
feat: window styles + tag renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ Open a floating window with all the tags for a given scope. This buffer is modif
 - **Quick select** (`1-9`): select the tag at a given index
 - **Deletion**: delete a line to delete the tag
 - **Reordering**: move a line to move a tag
+- **Renaming** (`R`): rename the tag under the cursor
 - **Quickfix** (`<c-q>`): send all tags to the quickfix list ([`:h quickfix`](https://neovim.io/doc/user/quickfix.html))
 - **Go up** (`-`): navigate up to the [scopes window](#scopes-window)
 

--- a/README.md
+++ b/README.md
@@ -679,6 +679,16 @@ require("grapple").open_loaded()
 
 </details>
 
+### Window Highlights
+
+| Highlight        | Default Link      | Style      | Used in                         |
+| ---------------- | ----------------- | ---------- | ------------------------------- |
+| `GrappleBold`    | N/A               | `gui=bold` | Scopes window for scope names   |
+| `GrappleHint`    | `Comment`         | N/A        | Tags window for directory hints |
+| `GrappleName`    | `DiagnosticHint`  | N/A        | Tags window for tag name        |
+| `GrappleNoExist` | `DiagnosticError` | N/A        | Tags window for tag status      |
+| `GrappleCurrent` | `SpecialChar`     | `gui=bold` | All windows for current status  |
+
 ## Persistent State
 
 Grapple saves all scopes to a common directory. The default directory is named `grapple` and lives in Neovim's `"data"` directory ([`:h standard-path`](https://neovim.io/doc/user/starting.html#standard-path)). Each scope will be saved as its own individually serialized JSON blob.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ vim.keymap.set("n", "<leader>1", "<cmd>Grapple select index=1<cr>")
     dependencies = {
         { "nvim-tree/nvim-web-devicons", lazy = true }
     },
-
 }
 ```
 
@@ -118,12 +117,23 @@ require("grapple").setup({
     ---@type boolean
     status = true,
 
+    ---Position a tag's name should be shown in Grapple windows
+    ---@type "start" | "end"
+    name_pos = "end",
+
+    ---How a tag's path should be rendered in Grapple windows
+    ---  "relative": show tag path relative to the scope's resolved path
+    ---  "basename": show tag path basename and directory hint
+    ---@type "basename" | "relative"
+    style = "relative",
+
     ---Default scope to use when managing Grapple tags
+    ---For more information, please see the Scopes section
     ---@type string
     scope = "git",
 
     ---User-defined scopes or overrides
-    ---For more information, please see the Scopes section
+    ---For more information, please see the Scope API section
     ---@type grapple.scope_definition[]
     scopes = {},
 

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -442,9 +442,10 @@ function Grapple.open_tags(opts)
         return vim.notify(err, vim.log.levels.ERROR)
     end
 
+    -- stylua: ignore
     local content = TagContent:new(
         scope,
-        app.settings.tag_styles[app.settings.tag_style],
+        app.settings.styles[app.settings.style],
         app.settings.tag_hook,
         app.settings.tag_title
     )

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -489,14 +489,12 @@ end
 function Grapple.initialize()
     -- Create highlights for Grapple windows
     vim.cmd("highlight default GrappleBold gui=bold cterm=bold")
-
-    vim.cmd("highlight default link GrappleNoExist DiagnosticError")
-    vim.cmd("highlight default link GrappleCurrent SpecialChar")
-    vim.cmd("highlight default link GrappleParent Comment")
+    vim.cmd("highlight default link GrappleHint Comment")
     vim.cmd("highlight default link GrappleName DiagnosticHint")
+    vim.cmd("highlight default link GrappleNoExist DiagnosticError")
 
-    vim.cmd("highlight default GrappleCurrentBold gui=bold cterm=bold")
-    vim.cmd("highlight! link GrappleCurrentBold GrappleCurrent")
+    vim.cmd("highlight default GrappleCurrent gui=bold cterm=bold")
+    vim.cmd("highlight! link GrappleCurrent SpecialChar")
 
     -- Create autocommand to keep Grapple state up-to-date
     vim.api.nvim_create_augroup("Grapple", { clear = true })

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -442,7 +442,12 @@ function Grapple.open_tags(opts)
         return vim.notify(err, vim.log.levels.ERROR)
     end
 
-    local content = TagContent:new(scope, app.settings.tag_hook, app.settings.tag_title)
+    local content = TagContent:new(
+        scope,
+        app.settings.tag_styles[app.settings.tag_style],
+        app.settings.tag_hook,
+        app.settings.tag_title
+    )
 
     open(content)
 end
@@ -484,10 +489,13 @@ end
 function Grapple.initialize()
     -- Create highlights for Grapple windows
     vim.cmd("highlight default GrappleBold gui=bold cterm=bold")
-    vim.cmd("highlight default GrappleCurrentBold gui=bold cterm=bold")
 
     vim.cmd("highlight default link GrappleNoExist DiagnosticError")
     vim.cmd("highlight default link GrappleCurrent SpecialChar")
+    vim.cmd("highlight default link GrappleParent Comment")
+    vim.cmd("highlight default link GrappleName DiagnosticHint")
+
+    vim.cmd("highlight default GrappleCurrentBold gui=bold cterm=bold")
     vim.cmd("highlight! link GrappleCurrentBold GrappleCurrent")
 
     -- Create autocommand to keep Grapple state up-to-date

--- a/lua/grapple/container_actions.lua
+++ b/lua/grapple/container_actions.lua
@@ -2,6 +2,9 @@ local ContainerActions = {}
 
 ---@class grapple.action.container_options
 ---
+---Provided by Window
+---@field window grapple.window
+---
 ---User-provided information
 ---@field id? string
 

--- a/lua/grapple/container_content.lua
+++ b/lua/grapple/container_content.lua
@@ -121,6 +121,27 @@ function ContainerContent:create_entry(entity, index)
         sign_highlight = "GrappleCurrent"
     end
 
+    ---@type grapple.vim.mark
+    local sign_mark = {
+        sign_text = string.format("%d", index),
+        sign_hl_group = sign_highlight,
+    }
+
+    local count = container:len()
+    local count_text = count == 1 and "tag" or "tags"
+    local count_mark = {
+        virt_text = { { string.format("[%d %s]", count, count_text) } },
+        virt_text_pos = "eol",
+    }
+
+    local extmarks = vim.tbl_map(function(mark)
+        return {
+            line = index - 1,
+            col = 0,
+            opts = mark,
+        }
+    end, { sign_mark, count_mark })
+
     ---@type grapple.window.entry
     local entry = {
         ---@class grapple.scope_content.data
@@ -136,20 +157,7 @@ function ContainerContent:create_entry(entity, index)
         highlights = {},
 
         ---@type grapple.vim.extmark[]
-        extmarks = {
-            {
-                line = index - 1,
-                col = 0,
-                opts = {
-                    sign_text = string.format("%d", index),
-                    sign_hl_group = sign_highlight,
-                    virt_text = { { string.format("[%d tags]", container:len()) } },
-
-                    -- TODO: requires nvim-0.10
-                    -- invalidate = true,
-                },
-            },
-        },
+        extmarks = extmarks,
     }
 
     return entry

--- a/lua/grapple/container_content.lua
+++ b/lua/grapple/container_content.lua
@@ -135,17 +135,19 @@ function ContainerContent:create_entry(entity, index)
         ---@type grapple.vim.highlight[]
         highlights = {},
 
-        ---@type grapple.vim.extmark
-        mark = {
-            line = index - 1,
-            col = 0,
-            opts = {
-                sign_text = string.format("%d", index),
-                sign_hl_group = sign_highlight,
-                virt_text = { { string.format("[%d tags]", container:len()) } },
+        ---@type grapple.vim.extmark[]
+        extmarks = {
+            {
+                line = index - 1,
+                col = 0,
+                opts = {
+                    sign_text = string.format("%d", index),
+                    sign_hl_group = sign_highlight,
+                    virt_text = { { string.format("[%d tags]", container:len()) } },
 
-                -- TODO: requires nvim-0.10
-                -- invalidate = true,
+                    -- TODO: requires nvim-0.10
+                    -- invalidate = true,
+                },
             },
         },
     }

--- a/lua/grapple/path.lua
+++ b/lua/grapple/path.lua
@@ -392,8 +392,14 @@ function Path.fs_relative(base, targ)
         return nil, err
     end
 
+    -- Add leading "./" to relative paths for better autocompletion
+    if not vim.startswith(path, "..") then
+        path = "." .. Path.separator .. path
+    end
+
+    -- Add trailing slash to directories
     if vim.fn.isdirectory(targ) == 1 then
-        path = path .. "/"
+        path = path .. Path.separator
     end
 
     return path

--- a/lua/grapple/path.lua
+++ b/lua/grapple/path.lua
@@ -344,7 +344,6 @@ end
 ---@return boolean
 function Path.is_joinable(path)
     return not vim.startswith(path, "./")
-        and not vim.startswith(path, "../")
         and not vim.startswith(path, "~")
         and not Path.is_uri(path)
         and not Path.is_absolute(path)
@@ -390,11 +389,6 @@ function Path.fs_relative(base, targ)
     local path, err = Path.relative(base, targ)
     if not path then
         return nil, err
-    end
-
-    -- Add leading "./" to relative paths for better autocompletion
-    if not vim.startswith(path, "..") then
-        path = "." .. Path.separator .. path
     end
 
     -- Add trailing slash to directories

--- a/lua/grapple/path.lua
+++ b/lua/grapple/path.lua
@@ -302,6 +302,40 @@ function Path.relative(base, targ)
     return rel_path, nil
 end
 
+---@param path string
+---@return string basename
+function Path.base(path)
+    if path == "" then
+        return "."
+    end
+
+    -- Remove trailing slashes
+    if Path.is_separator(path, -1) then
+        path = string.sub(path, 1, -2)
+    end
+
+    return vim.fn.fnamemodify(path, ":t")
+end
+
+---@param path string
+---@param n? integer
+---@return string basename
+function Path.parent(path, n)
+    if path == "" then
+        return "."
+    end
+
+    -- Remove trailing slashes
+    if Path.is_separator(path, -1) then
+        path = string.sub(path, 1, -2)
+    end
+
+    n = n or 1
+    local mods = table.concat(Util.ntimes(":h", n), "")
+
+    return vim.fn.fnamemodify(path, mods)
+end
+
 ---Not from the Go filepath package
 ---Check to see if a path can be the tail end of a join
 ---1. The path is relative to known directory (i.e. CWD or HOME)
@@ -415,6 +449,10 @@ end
 ---@param path string
 ---@return boolean exists
 function Path.exists(path)
+    if Path.is_uri(path) then
+        return true
+    end
+
     return vim.loop.fs_stat(path) ~= nil
 end
 

--- a/lua/grapple/resolved_scope.lua
+++ b/lua/grapple/resolved_scope.lua
@@ -15,7 +15,7 @@ function ResolvedScope:new(name, id, path, tag_manager)
     return setmetatable({
         name = name,
         id = id,
-        path = path,
+        path = path or vim.loop.cwd(),
         tag_manager = tag_manager,
     }, self)
 end

--- a/lua/grapple/scope_actions.lua
+++ b/lua/grapple/scope_actions.lua
@@ -2,6 +2,9 @@ local ScopeActions = {}
 
 ---@class grapple.action.scope_options
 ---
+---Provided by Window
+---@field window grapple.window
+---
 ---User-provided information
 ---@field name? string
 

--- a/lua/grapple/scope_content.lua
+++ b/lua/grapple/scope_content.lua
@@ -105,7 +105,7 @@ function ScopeContent:create_entry(entity, index)
 
     if app.settings.status and entity.current then
         sign_highlight = "GrappleCurrent"
-        name_group = "GrappleCurrentBold"
+        name_group = "GrappleCurrent"
     end
 
     local col_start = string.find(line, "%s")

--- a/lua/grapple/scope_content.lua
+++ b/lua/grapple/scope_content.lua
@@ -131,16 +131,18 @@ function ScopeContent:create_entry(entity, index)
         ---@type grapple.vim.highlight[]
         highlights = { name_highlight },
 
-        ---@type grapple.vim.extmark
-        mark = {
-            line = index - 1,
-            col = 0,
-            opts = {
-                sign_text = string.format("%d", index),
-                sign_hl_group = sign_highlight,
+        ---@type grapple.vim.extmark[]
+        extmarks = {
+            {
+                line = index - 1,
+                col = 0,
+                opts = {
+                    sign_text = string.format("%d", index),
+                    sign_hl_group = sign_highlight,
 
-                -- TODO: requires nvim-0.10
-                -- invalidate = true,
+                    -- TODO: requires nvim-0.10
+                    -- invalidate = true,
+                },
             },
         },
     }

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -153,7 +153,6 @@ local DEFAULT_SETTINGS = {
 
     ---@class grapple.stylized
     ---@field display string
-    ---@field highlights grapple.vim.highlight[]
     ---@field marks grapple.vim.mark[]
 
     ---Not user documented
@@ -165,7 +164,6 @@ local DEFAULT_SETTINGS = {
             ---@type grapple.stylized
             local line = {
                 display = assert(Path.fs_relative(assert(vim.loop.cwd()), entity.tag.path)),
-                highlights = {},
                 marks = {},
             }
 
@@ -191,7 +189,6 @@ local DEFAULT_SETTINGS = {
             ---@type grapple.stylized
             local line = {
                 display = Path.base(entity.tag.path),
-                highlights = {},
                 marks = { parent_mark },
             }
 

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -131,9 +131,17 @@ local DEFAULT_SETTINGS = {
         },
     },
 
+    ---Where a tag's name (if present) should be placed in the Tags Window
     ---@type "start" | "end"
     tag_name = "end",
 
+    ---How a tag's path should be displayed in the Tags Window
+    ---
+    ---Using "relative" will show the path relative to the user's current
+    ---working directory
+    ---
+    ---Using "basename" will show the path's basename with a directory hint
+    ---when more than one tag share the same basename
     ---@type "basename" | "relative"
     tag_style = "relative",
 

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -180,7 +180,7 @@ local DEFAULT_SETTINGS = {
                         "."
                             .. Path.separator
                             .. Path.relative(Path.parent(entity.tag.path, 3), Path.parent(entity.tag.path, 1)),
-                        "GrappleParent",
+                        "GrappleHint",
                     } },
                     virt_text_pos = "eol",
                 }

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -158,12 +158,12 @@ local DEFAULT_SETTINGS = {
     ---Not user documented
     ---@type table<string, grapple.tag_style_fn>
     tag_styles = {
-        relative = function(entity, _)
+        relative = function(entity, content)
             local Path = require("grapple.path")
 
             ---@type grapple.stylized
             local line = {
-                display = assert(Path.fs_relative(assert(vim.loop.cwd()), entity.tag.path)),
+                display = assert(Path.fs_relative(content.scope.path, entity.tag.path)),
                 marks = {},
             }
 

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -218,43 +218,43 @@ local DEFAULT_SETTINGS = {
         -- Select
         window:map("n", "<cr>", function()
             local cursor = window:cursor()
-            window:perform(TagActions.select, { index = cursor[1] })
+            window:perform_close(TagActions.select, { index = cursor[1] })
         end, { desc = "Select" })
 
         -- Select (horizontal split)
         window:map("n", "<c-s>", function()
             local cursor = window:cursor()
-            window:perform(TagActions.select, { index = cursor[1], command = vim.cmd.split })
+            window:perform_close(TagActions.select, { index = cursor[1], command = vim.cmd.split })
         end, { desc = "Select (split)" })
 
         -- Select (vertical split)
         window:map("n", "|", function()
             local cursor = window:cursor()
-            window:perform(TagActions.select, { index = cursor[1], command = vim.cmd.vsplit })
+            window:perform_close(TagActions.select, { index = cursor[1], command = vim.cmd.vsplit })
         end, { desc = "Select (vsplit)" })
 
         -- Quick select
         for i = 1, 9 do
             window:map("n", string.format("%s", i), function()
-                window:perform(TagActions.select, { index = i })
+                window:perform_close(TagActions.select, { index = i })
             end, { desc = string.format("Select %d", i) })
         end
 
         -- Quickfix list
         window:map("n", "<c-q>", function()
-            window:perform(TagActions.quickfix)
+            window:perform_close(TagActions.quickfix)
         end, { desc = "Quickfix" })
 
         -- Go "up" to scopes
         window:map("n", "-", function()
-            window:perform(TagActions.open_scopes)
+            window:perform_close(TagActions.open_scopes)
         end, { desc = "Go to scopes" })
 
         -- Rename a tag
         window:map("n", "<c-r>", function()
             local entry = window:current_entry()
             local path = entry.data.path
-            window:perform(TagActions.rename, { path = path, name = "bob" })
+            window:perform_retain(TagActions.rename, { path = path })
         end)
     end,
 
@@ -274,7 +274,7 @@ local DEFAULT_SETTINGS = {
         window:map("n", "<cr>", function()
             local entry = window:current_entry()
             local name = entry.data.name
-            window:perform(ScopeActions.open_tags, { name = name })
+            window:perform_close(ScopeActions.open_tags, { name = name })
         end, { desc = "Open scope" })
 
         -- Quick select
@@ -287,7 +287,7 @@ local DEFAULT_SETTINGS = {
                 end
 
                 local name = entry.data.name
-                window:perform(ScopeActions.open_tags, { name = name })
+                window:perform_close(ScopeActions.open_tags, { name = name })
             end, { desc = string.format("Open %d", i) })
         end
 
@@ -295,12 +295,12 @@ local DEFAULT_SETTINGS = {
         window:map("n", "<s-cr>", function()
             local entry = window:current_entry()
             local name = entry.data.name
-            window:perform(ScopeActions.change, { name = name })
+            window:perform_close(ScopeActions.change, { name = name })
         end, { desc = "Change scope" })
 
         -- Navigate "up" to loaded scopes
         window:map("n", "-", function()
-            window:perform(ScopeActions.open_loaded)
+            window:perform_close(ScopeActions.open_loaded)
         end, { desc = "Go to loaded scopes" })
     end,
 
@@ -320,7 +320,7 @@ local DEFAULT_SETTINGS = {
         window:map("n", "<cr>", function()
             local entry = window:current_entry()
             local id = entry.data.id
-            window:perform(ContainerActions.select, { id = id })
+            window:perform_close(ContainerActions.select, { id = id })
         end, { desc = "Open tags" })
 
         -- Quick select
@@ -333,7 +333,7 @@ local DEFAULT_SETTINGS = {
                 end
 
                 local name = entry and entry.data.name
-                window:perform(ContainerActions.select, { name = name })
+                window:perform_close(ContainerActions.select, { name = name })
             end, { desc = string.format("Select %d", i) })
         end
 
@@ -341,12 +341,12 @@ local DEFAULT_SETTINGS = {
         window:map("n", "x", function()
             local entry = window:current_entry()
             local id = entry.data.id
-            window:perform(ContainerActions.reset, { id = id })
+            window:perform_close(ContainerActions.reset, { id = id })
         end, { desc = "Reset scope" })
 
         -- Navigate "up" to scopes
         window:map("n", "-", function()
-            window:perform(ContainerActions.open_scopes)
+            window:perform_close(ContainerActions.open_scopes)
         end, { desc = "Go to scopes" })
     end,
 

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -197,8 +197,8 @@ local DEFAULT_SETTINGS = {
             window:perform_close(TagActions.open_scopes)
         end, { desc = "Go to scopes" })
 
-        -- Rename a tag
-        window:map("n", "<c-r>", function()
+        -- Rename
+        window:map("n", "R", function()
             local entry = window:current_entry()
             local path = entry.data.path
             window:perform_retain(TagActions.rename, { path = path })

--- a/lua/grapple/tag.lua
+++ b/lua/grapple/tag.lua
@@ -22,15 +22,6 @@ function Tag:update()
     self.cursor = vim.api.nvim_win_get_cursor(0)
 end
 
----@param name string | nil
-function Tag:rename(name)
-    if name == "" then
-        name = nil
-    end
-
-    self.name = name
-end
-
 ---@param command? function
 function Tag:select(command)
     local short_path = Path.fs_short(self.path)

--- a/lua/grapple/tag.lua
+++ b/lua/grapple/tag.lua
@@ -2,12 +2,13 @@ local Path = require("grapple.path")
 
 ---@class grapple.tag
 ---@field path string absolute path
----@field name string tag name
+---@field name string | nil (optional) tag name
 ---@field cursor integer[] (1, 0)-indexed cursor position
 local Tag = {}
 Tag.__index = Tag
 
 ---@param path string
+---@param name? string
 ---@param cursor? integer[]
 function Tag:new(path, name, cursor)
     return setmetatable({
@@ -19,6 +20,15 @@ end
 
 function Tag:update()
     self.cursor = vim.api.nvim_win_get_cursor(0)
+end
+
+---@param name string | nil
+function Tag:rename(name)
+    if name == "" then
+        name = nil
+    end
+
+    self.name = name
 end
 
 ---@param command? function

--- a/lua/grapple/tag_actions.lua
+++ b/lua/grapple/tag_actions.lua
@@ -41,9 +41,7 @@ function TagActions.rename(opts)
             if not index then
                 return err
             end
-
-            local tag = assert(container:get({ index = index }))
-            tag:rename(input_name)
+            container:insert({ path = opts.path, name = input_name, index = index })
         end)
     end)
 end

--- a/lua/grapple/tag_actions.lua
+++ b/lua/grapple/tag_actions.lua
@@ -47,6 +47,8 @@ function TagActions.rename(opts)
             container:insert({ path = opts.path, name = input_name, index = index })
         end)
 
+        -- Re-render window once tag has been renamed, regardless of whether
+        -- the renaming was successful
         opts.window:render()
     end)
 end

--- a/lua/grapple/tag_actions.lua
+++ b/lua/grapple/tag_actions.lua
@@ -30,6 +30,26 @@ end
 
 ---@param opts grapple.action.tag_options
 ---@return string? error
+function TagActions.rename(opts)
+    vim.ui.input({ prompt = string.format("Rename %s", opts.path) }, function(input_name)
+        if not input_name then
+            return
+        end
+
+        opts.scope:enter(function(container)
+            local index, err = container:find({ path = opts.path })
+            if not index then
+                return err
+            end
+
+            local tag = assert(container:get({ index = index }))
+            tag:rename(input_name)
+        end)
+    end)
+end
+
+---@param opts grapple.action.tag_options
+---@return string? error
 function TagActions.quickfix(opts)
     require("grapple").quickfix({ scope = opts.scope.name })
 end

--- a/lua/grapple/tag_actions.lua
+++ b/lua/grapple/tag_actions.lua
@@ -1,11 +1,12 @@
-local Path = require("grapple.path")
-
 local TagActions = {}
 
 ---@alias grapple.action.options table
 ---@alias grapple.action fun(opts?: table): string?
 
 ---@class grapple.action.tag_options
+---
+---Provided by Window
+---@field window grapple.window
 ---
 ---Provided by TagContent
 ---@field scope grapple.resolved_scope
@@ -31,7 +32,9 @@ end
 ---@param opts grapple.action.tag_options
 ---@return string? error
 function TagActions.rename(opts)
-    vim.ui.input({ prompt = string.format("Rename %s", opts.path) }, function(input_name)
+    local Path = require("grapple.path")
+
+    vim.ui.input({ prompt = string.format("Rename %s", Path.fs_short(opts.path)) }, function(input_name)
         if not input_name then
             return
         end
@@ -43,6 +46,8 @@ function TagActions.rename(opts)
             end
             container:insert({ path = opts.path, name = input_name, index = index })
         end)
+
+        opts.window:render()
     end)
 end
 

--- a/lua/grapple/tag_content.lua
+++ b/lua/grapple/tag_content.lua
@@ -216,7 +216,6 @@ function TagContent:create_entry(entity, index)
     highlights = vim.tbl_filter(Util.not_nil, {
         icon_highlight,
         name_highlight,
-        unpack(stylized.highlights),
     })
 
     -- Define line extmarks
@@ -229,6 +228,7 @@ function TagContent:create_entry(entity, index)
         sign_hl_group = sign_highlight,
     }
 
+    ---@type grapple.vim.mark
     local name_mark
     if app.settings.tag_name == "end" and tag.name then
         name_mark = {
@@ -323,6 +323,9 @@ function TagContent:parse_line(line, original_entries)
             entry.modified = false
 
             return entry
+        else
+            -- Keep the name associated with the original entry
+            entry.data.name = data.name
         end
     end
 

--- a/lua/grapple/tag_content.lua
+++ b/lua/grapple/tag_content.lua
@@ -120,8 +120,8 @@ local function get_icon(path)
     if not ok then
         -- stylua: ignore
         error(
-            'The plugin "nvim-tree/nvim-web-devicons" is required for icons in Grapple.nvim.' ..
-            ' To disable icons, change "icons" to false in the settings.'
+            'The plugin "nvim-tree/nvim-web-devicons" is required for icons in Grapple.nvim. ' ..
+            'To disable icons, change "icons" to false in the settings.'
         )
     end
 
@@ -298,6 +298,7 @@ function TagContent:parse_line(line, original_entries)
     local entry = {
         ---@type grapple.tag_content.data
         data = {
+            display = display,
             path = nil,
             name = nil,
             cursor = nil,
@@ -329,11 +330,16 @@ function TagContent:parse_line(line, original_entries)
         end
     end
 
-    -- TODO: could this be improved for display text that has only been
-    -- slightly modified?
-    --
+    local path = display
+
+    -- The display path has been modified. Only join if it is not explicitly
+    -- relative to another known directory (i.e. starts with "./" or "~")
+    if Path.is_joinable(path) then
+        path = Path.join(self.scope.path, path)
+    end
+
     -- Parse as a new entry when the display text has been modified
-    entry.data.path = Path.fs_absolute(display)
+    entry.data.path = Path.fs_absolute(path)
 
     return entry
 end

--- a/lua/grapple/tag_content.lua
+++ b/lua/grapple/tag_content.lua
@@ -169,7 +169,7 @@ function TagContent:create_entry(entity, index)
         -- instead of just "overlay". Render the name ahead of the displayed
         -- path instead of as an extmark when the user wants to show it at the
         -- start of the line
-        app.settings.tag_name == "start" and tag.name or nil,
+        app.settings.name_pos == "start" and tag.name or nil,
 
         stylized.display,
     })
@@ -203,7 +203,7 @@ function TagContent:create_entry(entity, index)
     end
 
     local name_highlight
-    if app.settings.tag_name == "start" and tag.name then
+    if app.settings.name_pos == "start" and tag.name then
         local col_start, col_end = assert(string.find(line, tag.name))
         name_highlight = {
             hl_group = "GrappleName",
@@ -230,7 +230,7 @@ function TagContent:create_entry(entity, index)
 
     ---@type grapple.vim.mark
     local name_mark
-    if app.settings.tag_name == "end" and tag.name then
+    if app.settings.name_pos == "end" and tag.name then
         name_mark = {
             virt_text = { { tag.name, "GrappleName" } },
             virt_text_pos = "eol",

--- a/lua/grapple/tag_content.lua
+++ b/lua/grapple/tag_content.lua
@@ -208,7 +208,7 @@ function TagContent:create_entry(entity, index)
         name_highlight = {
             hl_group = "GrappleName",
             line = index - 1,
-            col_start = col_start,
+            col_start = col_start - 1,
             col_end = col_end,
         }
     end

--- a/lua/grapple/tag_content.lua
+++ b/lua/grapple/tag_content.lua
@@ -83,18 +83,11 @@ function TagContent:entities()
         return nil, err
     end
 
-    local base_lookup = Util.reduce(
-        tags,
-        ---@param lookup table<string, integer>
-        ---@param tag grapple.tag
-        ---@return table<string, integer> lookup
-        function(lookup, tag)
-            local base = Path.base(tag.path)
-            lookup[base] = (lookup[base] or 0) + 1
-            return lookup
-        end,
-        {}
-    )
+    local base_lookup = Util.reduce(tags, function(lookup, tag)
+        local base = Path.base(tag.path)
+        lookup[base] = (lookup[base] or 0) + 1
+        return lookup
+    end, {})
 
     ---@type grapple.window.entity[]
     local entities = {}

--- a/lua/grapple/types.lua
+++ b/lua/grapple/types.lua
@@ -21,6 +21,12 @@ function Deserializable.from_table(tbl) end
 ---@field col integer
 ---@field opts? table<string, any>
 
+---@class grapple.vim.mark
+---@field sign_hl_group? string
+---@field sign_text? string
+---@field virt_text? string[][]
+---@field virt_text_win_col? integer
+
 ---See :h nvim_buf_add_highlight
 ---@class grapple.vim.highlight
 ---@field hl_group string

--- a/lua/grapple/util.lua
+++ b/lua/grapple/util.lua
@@ -48,6 +48,18 @@ function Util.subtract(tbl, removed)
 end
 
 ---@generic T
+---@param value T
+---@param n integer
+---@return T[]
+function Util.ntimes(value, n)
+    local result = {}
+    for _ = 1, n do
+        table.insert(result, value)
+    end
+    return result
+end
+
+---@generic T
 ---@param list_a T[]
 ---@param list_b T[]
 ---@return boolean

--- a/lua/grapple/window.lua
+++ b/lua/grapple/window.lua
@@ -211,7 +211,7 @@ end
 ---@field index integer
 ---@field min_col integer
 ---@field highlights grapple.vim.highlight[]
----@field mark grapple.vim.extmark | nil
+---@field extmarks grapple.vim.extmark[]
 
 ---@class grapple.window.parsed_entry
 ---@field data any
@@ -220,7 +220,7 @@ end
 ---@field index? integer
 ---@field min_col? integer
 ---@field highlights? grapple.vim.highlight[]
----@field mark? grapple.vim.extmark | nil
+---@field extmarks? grapple.vim.extmark[]
 
 ---@return grapple.window.parsed_entry[] | nil, string? error
 function Window:parse_lines()
@@ -289,9 +289,9 @@ end
 
 ---Convenience function for getting the extmark for an entry
 ---@param entry grapple.window.entry
----@return grapple.vim.extmark?
-local function to_mark(entry)
-    return entry.mark
+---@return grapple.vim.extmark[]
+local function to_extmarks(entry)
+    return entry.extmarks
 end
 
 ---@return string? error
@@ -353,8 +353,10 @@ function Window:render()
         end
     end
 
-    for _, mark in ipairs(vim.tbl_map(to_mark, self.entries)) do
-        vim.api.nvim_buf_set_extmark(self.buf_id, self.ns_id, mark.line, mark.col, mark.opts)
+    for _, entry_extmarks in ipairs(vim.tbl_map(to_extmarks, self.entries)) do
+        for _, extmark in ipairs(entry_extmarks) do
+            vim.api.nvim_buf_set_extmark(self.buf_id, self.ns_id, extmark.line, extmark.col, extmark.opts)
+        end
     end
 
     -- Prevent undo after content has been rendered. Set undolevels to -1 when


### PR DESCRIPTION
## Context

Fixes #105

**Todo**

- [x] Prevent tag renaming from closing the Tags window
- [x] Add README docs for styles
- [x] Add README docs for highlights
- [x] Add README docs for tag renaming

## Changes

- fix: updating the path for a tag in the Tags window now longer causes the tag's name to be lost
- fix: The displayed count in the Loaded Scopes window is now correctly pluralized when there are 0, 1, or more tags

### Window styles

Path rendering and name position for the Tags window is now configurable through the settings.

#### Using `style = "relative"` and `name_pos = "start"`

<img width="1059" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/2467016/2543b790-42fb-42d5-9d00-618e03510871">

#### Using `style = "basename"` and `name_pos = "end"`

<img width="1059" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/2467016/a4d08a6a-8fd5-4b3a-92d0-e7d7b9e74d03">

### Tag renaming

Tags can now be renamed in the Tags window. The default mapping is `R`.

<img width="1059" alt="image" src="https://github.com/cbochs/grapple.nvim/assets/2467016/46962b46-00bc-4857-86ef-b4b81a795c30">