### PR TITLE
fix: minimum column

### DIFF
--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -606,7 +606,6 @@ function Grapple.initialize()
                 -- "new" kwargs refer to methods that create a new tag (i.e. tag)
                 -- "use" kwargs refer to methods that use an existing tag (i.e. select)
                 -- "scope" kwargs refer to methods that operate on a scope (i.e. quickfix)
-                -- TODO: allow "command" as a string argument for "use" kwargs
                 local tag_kwargs = { "buffer", "path", "name", "index", "scope", "command" }
                 local new_kwargs = Util.subtract(tag_kwargs, { "command" })
                 local use_kwargs = Util.subtract(tag_kwargs, { "command" })

--- a/lua/grapple/container_content.lua
+++ b/lua/grapple/container_content.lua
@@ -25,6 +25,15 @@ function ContainerContent:modifiable()
     return false
 end
 
+---Return the first editable cursor column for a line (0-indexed)
+---@param _ string line
+function ContainerContent:minimum_column(_)
+    -- Assume: buffer is unmodifiable line contains two items: an id and path
+    -- The id is in the form "/000" and followed by a space. Therefore the
+    -- minimum column should be at 5 (0-indexed)
+    return 5
+end
+
 ---@return string | nil title
 function ContainerContent:title()
     if not self.title_fn then
@@ -179,7 +188,7 @@ end
 ---@param original_entries grapple.window.entry[]
 ---@return grapple.window.parsed_entry
 function ContainerContent:parse_line(line, original_entries)
-    local id, _ = string.match(line, "^/(%d+) (%S+)")
+    local id = string.match(line, "^/(%d+)")
     local index = assert(tonumber(id))
 
     ---@type grapple.window.parsed_entry

--- a/lua/grapple/scope_content.lua
+++ b/lua/grapple/scope_content.lua
@@ -24,6 +24,15 @@ function ScopeContent:modifiable()
     return false
 end
 
+---Return the first editable cursor column for a line (0-indexed)
+---@param _ string line
+function ScopeContent:minimum_column(_)
+    -- Assume: buffer is unmodifiable line contains two items: an id and path
+    -- The id is in the form "/000" and followed by a space. Therefore the
+    -- minimum column should be at 5 (0-indexed)
+    return 5
+end
+
 ---@return string | nil title
 function ScopeContent:title()
     if not self.title_fn then
@@ -168,7 +177,7 @@ end
 ---@param original_entries grapple.window.entry[]
 ---@return grapple.window.parsed_entry
 function ScopeContent:parse_line(line, original_entries)
-    local id, _ = string.match(line, "^/(%d+) (%S+) %S+")
+    local id = string.match(line, "^/(%d+)")
     local index = assert(tonumber(id))
 
     ---@type grapple.window.parsed_entry

--- a/lua/grapple/tag_content.lua
+++ b/lua/grapple/tag_content.lua
@@ -36,6 +36,7 @@ end
 function TagContent:minimum_column(line)
     -- Assume: editable content is always at the end of the line
     -- Assume: name can be part of the line if "name_pos" is set to "start"
+    -- new:            1 split:  (path)
     -- base:           2 splits: (id, path)
     -- w/ name:        3 splits: (id, name, path)
     -- w/ icon:        3 splits: (id, icon, path)
@@ -44,13 +45,8 @@ function TagContent:minimum_column(line)
     if #split <= 1 then
         return 0
     else
-        if split[#split] == "" then
-            local _, e = string.find(line, split[#split - 1])
-            return e + 1
-        else
-            local s, _ = string.find(line, split[#split])
-            return s - 1
-        end
+        local _, e = string.find(line, split[#split - 1])
+        return e + 1
     end
 end
 

--- a/lua/grapple/tag_content.lua
+++ b/lua/grapple/tag_content.lua
@@ -34,9 +34,13 @@ end
 ---@param line string
 ---@return integer min_col
 function TagContent:minimum_column(line)
+    local id = string.match(line, "^/(%d+)")
+    if not id then
+        return 0
+    end
+
     -- Assume: editable content is always at the end of the line
     -- Assume: name can be part of the line if "name_pos" is set to "start"
-    -- new:            1 split:  (path)
     -- base:           2 splits: (id, path)
     -- w/ name:        3 splits: (id, name, path)
     -- w/ icon:        3 splits: (id, icon, path)

--- a/lua/grapple/tag_content.lua
+++ b/lua/grapple/tag_content.lua
@@ -30,6 +30,30 @@ function TagContent:modifiable()
     return true
 end
 
+---Return the first editable cursor column for a line (0-indexed)
+---@param line string
+---@return integer min_col
+function TagContent:minimum_column(line)
+    -- Assume: editable content is always at the end of the line
+    -- Assume: name can be part of the line if "name_pos" is set to "start"
+    -- base:           2 splits: (id, path)
+    -- w/ name:        3 splits: (id, name, path)
+    -- w/ icon:        3 splits: (id, icon, path)
+    -- w/ icon + name: 4 splits: (id, icon, name, path)
+    local split = vim.split(line, "%s+")
+    if #split <= 1 then
+        return 0
+    else
+        if split[#split] == "" then
+            local _, e = string.find(line, split[#split - 1])
+            return e + 1
+        else
+            local s, _ = string.find(line, split[#split])
+            return s - 1
+        end
+    end
+end
+
 ---@return string | nil title
 function TagContent:title()
     if not self.title_fn then
@@ -278,17 +302,18 @@ end
 function TagContent:parse_line(line, original_entries)
     local id = string.match(line, "^/(%d+)")
 
-    local index, display, original_entry
+    local index, display
     if id then
         index = assert(tonumber(id))
-        original_entry = original_entries[index]
-        display = vim.trim(string.sub(line, original_entry.min_col))
     else
         -- Parse as a new entry when an ID is not present
         index = nil
-        original_entry = nil
-        display = vim.trim(line)
     end
+
+    -- Minimum column returns the 0-indexed cursor column, convert to
+    -- 1-indexed before using it
+    local min_col = self:minimum_column(line) + 1
+    display = vim.trim(string.sub(line, min_col))
 
     -- Create an empty parsed entry, assume modified
     ---@type grapple.window.parsed_entry
@@ -310,9 +335,13 @@ function TagContent:parse_line(line, original_entries)
         return entry
     end
 
-    if original_entry then
+    -- TODO: parsing probably shouldn't need access to the original entries.
+    -- I do think it might be valuable to provide the line and extmarks linewise
+    -- extmarks, but likely this logic to get the original entry should be
+    -- pushed to the "diff" function
+    if original_entries[index] then
         ---@type grapple.tag_content.data
-        local data = original_entry.data
+        local data = original_entries[index].data
 
         if data.display == display then
             ---@type grapple.window.parsed_entry

--- a/lua/grapple/window.lua
+++ b/lua/grapple/window.lua
@@ -209,16 +209,16 @@ end
 ---@field data table
 ---@field line string
 ---@field index integer
----@field min_col integer
+---@field min_col integer unused now
 ---@field highlights grapple.vim.highlight[]
 ---@field extmarks grapple.vim.extmark[]
 
 ---@class grapple.window.parsed_entry
 ---@field data any
 ---@field line string
----@field modified boolean
+---@field modified boolean unused (for now)
 ---@field index? integer
----@field min_col? integer
+---@field min_col? integer unused now
 ---@field highlights? grapple.vim.highlight[]
 ---@field extmarks? grapple.vim.extmark[]
 
@@ -249,14 +249,7 @@ end
 ---@param line string
 ---@return integer min_col
 function Window:minimum_column(line)
-    local parsed_entry = self.content:parse_line(line, self.entries)
-
-    local index = parsed_entry.index
-    if not index then
-        return 0
-    end
-
-    return self.entries[index].min_col
+    return self.content:minimum_column(line)
 end
 
 ---@return string? error

--- a/tests/grapple/tag_content_spec.lua
+++ b/tests/grapple/tag_content_spec.lua
@@ -6,21 +6,35 @@ describe("TagContent", function()
             -- ID only
             { 5, "/000 /some_path" },
             { 5, "/000 " },
+            { 5, "/000           " },
+
+            -- ID + name
+            { 9, "/001 bob /some_path" },
+            { 9, "/001 bob " },
+            { 7, "/001 a /some_path" },
+            { 7, "/001 a " },
+            { 7, "/001 a           " },
 
             -- ID + icon
             { 9, "/001  /some_path" },
-            { 9, "/001  " },
+            { 9, "/002  /some_path" },
+            { 9, "/003  /some_path" },
+            { 9, "/004  " },
+            { 9, "/005            " },
 
             -- ID + icon + name
             { 13, "/001  bob /some_path" },
             { 13, "/001  bob " },
+            { 11, "/001  c /some_path" },
+            { 11, "/001  c " },
+            { 11, "/001  c           " },
         }
 
         for _, test_case in ipairs(test_cases) do
             local expected = test_case[1]
             local line = test_case[2]
 
-            it(string.format("line %s, min_col %d", line, expected), function()
+            it(string.format('expected col %d, line "%s"', expected, line), function()
                 assert.same(expected, TagContent:new(nil, nil, nil, nil):minimum_column(line))
             end)
         end

--- a/tests/grapple/tag_content_spec.lua
+++ b/tests/grapple/tag_content_spec.lua
@@ -7,9 +7,12 @@ describe("TagContent", function()
             { 5, "/000 /some_path" },
             { 5, "/000 " },
             { 5, "/000           " },
+            { 5, "/000           /some_path" },
 
             -- ID + name
             { 9, "/001 bob /some_path" },
+            { 9, "/001 bob bob" },
+            { 9, "/001 bob      bob  " },
             { 9, "/001 bob " },
             { 7, "/001 a /some_path" },
             { 7, "/001 a " },
@@ -28,6 +31,9 @@ describe("TagContent", function()
             { 11, "/001  c /some_path" },
             { 11, "/001  c " },
             { 11, "/001  c           " },
+
+            -- Assumed behaviour (last part editable)
+            { 16, "/000 /some_path /another_path" },
         }
 
         for _, test_case in ipairs(test_cases) do

--- a/tests/grapple/tag_content_spec.lua
+++ b/tests/grapple/tag_content_spec.lua
@@ -3,6 +3,16 @@ local TagContent = require("grapple.tag_content")
 describe("TagContent", function()
     describe(".minimum_column", function()
         local test_cases = {
+            -- No ID or invalid ID
+            { 0, "" },
+            { 0, "/some_path" },
+            { 0, "/001/some_path" },
+            { 0, "001" },
+
+            -- Partial ID
+            { 3, "/0 /some_path" },
+            { 4, "/00 /some_path" },
+
             -- ID only
             { 5, "/000 /some_path" },
             { 5, "/000 " },
@@ -11,12 +21,12 @@ describe("TagContent", function()
 
             -- ID + name
             { 9, "/001 bob /some_path" },
-            { 9, "/001 bob bob" },
-            { 9, "/001 bob      bob  " },
-            { 9, "/001 bob " },
-            { 7, "/001 a /some_path" },
-            { 7, "/001 a " },
-            { 7, "/001 a           " },
+            { 9, "/002 bob bob" },
+            { 9, "/003 bob      bob  " },
+            { 9, "/004 bob " },
+            { 7, "/005 a /some_path" },
+            { 7, "/006 a " },
+            { 7, "/007 a           " },
 
             -- ID + icon
             { 9, "/001  /some_path" },
@@ -27,10 +37,10 @@ describe("TagContent", function()
 
             -- ID + icon + name
             { 13, "/001  bob /some_path" },
-            { 13, "/001  bob " },
-            { 11, "/001  c /some_path" },
-            { 11, "/001  c " },
-            { 11, "/001  c           " },
+            { 13, "/002  bob " },
+            { 11, "/003  c /some_path" },
+            { 11, "/004  c " },
+            { 11, "/005  c           " },
 
             -- Assumed behaviour (last part editable)
             { 16, "/000 /some_path /another_path" },

--- a/tests/grapple/tag_content_spec.lua
+++ b/tests/grapple/tag_content_spec.lua
@@ -1,0 +1,28 @@
+local TagContent = require("grapple.tag_content")
+
+describe("TagContent", function()
+    describe(".minimum_column", function()
+        local test_cases = {
+            -- ID only
+            { 5, "/000 /some_path" },
+            { 5, "/000 " },
+
+            -- ID + icon
+            { 9, "/001  /some_path" },
+            { 9, "/001  " },
+
+            -- ID + icon + name
+            { 13, "/001  bob /some_path" },
+            { 13, "/001  bob " },
+        }
+
+        for _, test_case in ipairs(test_cases) do
+            local expected = test_case[1]
+            local line = test_case[2]
+
+            it(string.format("line %s, min_col %d", line, expected), function()
+                assert.same(expected, TagContent:new(nil, nil, nil, nil):minimum_column(line))
+            end)
+        end
+    end)
+end)


### PR DESCRIPTION
### Context

Right now copy/pasting tags from one scope to another results in an error due to there being no "original entry" for that each line pasted into a different scope. Of course there isn't, the it's coming from a different scope entirely!

For now, push the "minimum column" calculations to the content provider itself and calculate it on the fly instead of pre-calculating it as part of the window entry. This might change later if some form of "global state" is added to associate a line's ID with any tag with any tag container.