### PR TITLE
feat: use quick_select for statusline

### DIFF
--- a/lua/lualine/components/grapple.lua
+++ b/lua/lualine/components/grapple.lua
@@ -37,7 +37,7 @@ function Component:update_status()
     local quick_select = app.settings:quick_select()
     local output = {}
     for i, tag in ipairs(tags) do
-        -- stylus: ignore
+        -- stylua: ignore
         local tag_str = tag.name and tag.name
             or quick_select[i] and quick_select[i]
             or i

--- a/lua/lualine/components/grapple.lua
+++ b/lua/lualine/components/grapple.lua
@@ -32,9 +32,21 @@ function Component:update_status()
 
     local current = grapple.find({ buffer = 0 })
 
+    local app_ok, app = pcall(require, "grapple.app")
+    local quick_select = nil
+    if app_ok then
+        quick_select = app.get().settings:quick_select()
+    end
+
     local output = {}
     for i, tag in ipairs(tags) do
-        local tag_str = tag.name and tag.name or i
+        local tag_str = tostring(i)
+        if tag.name then
+            tag_str = tag.name
+        elseif quick_select and quick_select[i] then
+            tag_str = quick_select[i]
+        end
+
         local tag_fmt = self.options.inactive
         if current and current.path == tag.path then
             tag_fmt = self.options.active

--- a/lua/lualine/components/grapple.lua
+++ b/lua/lualine/components/grapple.lua
@@ -37,12 +37,10 @@ function Component:update_status()
     local quick_select = app.settings:quick_select()
     local output = {}
     for i, tag in ipairs(tags) do
-        local tag_str = tostring(i)
-        if tag.name then
-            tag_str = tag.name
-        elseif quick_select and quick_select[i] then
-            tag_str = quick_select[i]
-        end
+        -- stylus: ignore
+        local tag_str = tag.name and tag.name
+            or quick_select[i] and quick_select[i]
+            or i
 
         local tag_fmt = self.options.inactive
         if current and current.path == tag.path then

--- a/lua/lualine/components/grapple.lua
+++ b/lua/lualine/components/grapple.lua
@@ -32,12 +32,9 @@ function Component:update_status()
 
     local current = grapple.find({ buffer = 0 })
 
-    local app_ok, app = pcall(require, "grapple.app")
-    local quick_select = nil
-    if app_ok then
-        quick_select = app.get().settings:quick_select()
-    end
-
+    local App = require("grapple.app")
+    local app = App.get()
+    local quick_select = app.settings:quick_select()
     local output = {}
     for i, tag in ipairs(tags) do
         local tag_str = tostring(i)


### PR DESCRIPTION
![Screenshot 2024-03-18 at 10 28 04 AM](https://github.com/cbochs/grapple.nvim/assets/53562817/776509c5-0f50-465f-a28c-4c10d743a3d7)

I think bester if we use `quick_select` for statusline.

The priority: `tag name` -> `quick_select` -> `index`