### PR TITLE
Added basic scope support to lualine

### DIFF
--- a/lua/lualine/components/grapple.lua
+++ b/lua/lualine/components/grapple.lua
@@ -15,7 +15,8 @@ function Component:init(opts)
     Component.super:init(opts)
 end
 
-function Component:update_status()
+---@param opts? grapple.options
+function Component:update_status(opts)
     if package.loaded["grapple"] == nil then
         return
     end
@@ -25,12 +26,14 @@ function Component:update_status()
         return
     end
 
-    local tags, err = grapple.tags()
+    opts = opts or {}
+    local merged = vim.tbl_deep_extend("force", opts, { buffer = 0 })
+    local tags, err = grapple.tags(merged)
     if not tags then
         return err
     end
 
-    local current = grapple.find({ buffer = 0 })
+    local current = grapple.find(merged)
 
     local App = require("grapple.app")
     local app = App.get()


### PR DESCRIPTION
Closes: https://github.com/cbochs/grapple.nvim/issues/136

Not saying this is the most idiomatic / best way to do this but I took a quick stab before bed :)

## Demo

This PR + this configuration

```lua
require("lualine").setup {
  sections = {
    lualine_c = {
        {
            function()
                local component = require("lualine.components.grapple")
                component:init()
                local status = component:update_status({scope="git_branch"})

                if not status
                then
                    return "<Grapple Not Found>"
                end

                return status
            end,
        },
    },
}
```

Gives you

https://github.com/cbochs/grapple.nvim/assets/10103049/0eaf8af4-8ac0-44ea-81ea-2b525b512aed

## Details
I liked the lualine `{"grapple"}` component because it's concise and works well. If there's a way to get the above effect in a more concise way, that'd be cool