### PR TITLE
feat: prune scope save files based on last modified time

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ require("grapple").setup({
 
     ---Time limit used for pruning unused scope (IDs). If a scope's save file
     ---modified time exceeds this limit, then it will be deleted when a prune
-    ---requested. Can be an integer (in milliseconds) or a string time delta
+    ---requested. Can be an integer (in milliseconds) or a string time limit
     ---(e.g. "30d" or "2h" or "15m")
     ---@type integer | string
     prune = "30d",

--- a/README.md
+++ b/README.md
@@ -244,12 +244,19 @@ require("grapple").setup({
 
     ---A string of characters used for quick selecting in Grapple windows
     ---An empty string or false will disable quick select
-    ---@type string | nil
+    ---@type string | boolean
     quick_select = "123456789",
 
     ---Default command to use when selecting a tag
     ---@type fun(path: string)
     command = vim.cmd.edit,
+
+    ---Time limit used for pruning unused scope (IDs). If a scope's save file
+    ---modified time exceeds this limit, then it will be deleted when a prune
+    ---requested. Can be an integer (in milliseconds) or a string time delta
+    ---(e.g. "30d" or "2h" or "15m")
+    ---@type integer | string
+    prune = "30d",
 
     ---User-defined tags title function for Grapple windows
     ---By default, uses the resolved scope's ID

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -440,6 +440,10 @@ function Grapple.prune(opts)
         return nil, err
     end
 
+    if opts.notify then
+        vim.notify(string.format("Pruned %d save files", #pruned_ids), vim.log.levels.INFO)
+    end
+
     return pruned_ids, nil
 end
 

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -423,8 +423,8 @@ function Grapple.reset(opts)
     end
 end
 
----Prune
----@param opts? { ttl?: integer | string, notify?: boolean }
+---Prune Grapple save files based on their last modified time (mtime)
+---@param opts? { mtime?: integer | string, notify?: boolean }
 ---@return string[] | nil, string? error
 function Grapple.prune(opts)
     local App = require("grapple.app")
@@ -432,7 +432,7 @@ function Grapple.prune(opts)
 
     opts = opts or {}
 
-    local pruned_ids, err = app.tag_manager:prune(opts.until or app.settings.prune)
+    local pruned_ids, err = app.tag_manager:prune(opts.mtime or app.settings.prune)
     if not pruned_ids then
         if opts.notify then
             vim.notify(err, vim.log.levels.ERROR)
@@ -684,7 +684,7 @@ function Grapple.initialize()
                     open_loaded    = { args = {},              kwargs = { "all" } },
                     open_scopes    = { args = {},              kwargs = {} },
                     open_tags      = { args = {},              kwargs = window_kwargs },
-                    prune          = { args = {},              kwargs = { "ttl" } },
+                    prune          = { args = {},              kwargs = { "mtime" } },
                     quickfix       = { args = {},              kwargs = scope_kwargs },
                     reset          = { args = {},              kwargs = scope_kwargs },
                     select         = { args = {},              kwargs = use_kwargs },

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -424,6 +424,20 @@ function Grapple.reset(opts)
     end
 end
 
+---@param opts { ttl: integer | string }
+---@return string[] | nil, string? error
+function Grapple.prune(opts)
+    local App = require("grapple.app")
+    local app = App.get()
+
+    local pruned_ids, err = app.tag_manager:prune(opts.ttl)
+    if not pruned_ids then
+        return nil, err
+    end
+
+    return pruned_ids, nil
+end
+
 ---Create a user-defined scope
 ---@param definition grapple.scope_definition
 ---@return string? error

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -423,16 +423,17 @@ function Grapple.reset(opts)
     end
 end
 
----Prune Grapple save files based on their last modified time (mtime)
----@param opts? { mtime?: integer | string, notify?: boolean }
+---Prune save files based on their last modified time
+---@param opts? { limit?: integer | string, notify?: boolean }
 ---@return string[] | nil, string? error
 function Grapple.prune(opts)
+    local Util = require("grapple.util")
     local App = require("grapple.app")
     local app = App.get()
 
     opts = opts or {}
 
-    local pruned_ids, err = app.tag_manager:prune(opts.mtime or app.settings.prune)
+    local pruned_ids, err = app.tag_manager:prune(opts.limit or app.settings.prune)
     if not pruned_ids then
         if opts.notify then
             vim.notify(err, vim.log.levels.ERROR)
@@ -441,7 +442,16 @@ function Grapple.prune(opts)
     end
 
     if opts.notify then
-        vim.notify(string.format("Pruned %d save files", #pruned_ids), vim.log.levels.INFO)
+        if #pruned_ids == 0 then
+            vim.notify("Pruned 0 save files", vim.log.levels.INFO)
+        elseif #pruned_ids == 1 then
+            vim.notify(string.format("Pruned %d save file: %s", #pruned_ids, pruned_ids[1]), vim.log.levels.INFO)
+        else
+            vim.print(pruned_ids)
+            local output_tbl = vim.tbl_map(Util.with_prefix("  "), pruned_ids)
+            local output = table.concat(output_tbl, "\n")
+            vim.notify(string.format("Pruned %d save files\n%s", #pruned_ids, output), vim.log.levels.INFO)
+        end
     end
 
     return pruned_ids, nil
@@ -688,7 +698,7 @@ function Grapple.initialize()
                     open_loaded    = { args = {},              kwargs = { "all" } },
                     open_scopes    = { args = {},              kwargs = {} },
                     open_tags      = { args = {},              kwargs = window_kwargs },
-                    prune          = { args = {},              kwargs = { "mtime" } },
+                    prune          = { args = {},              kwargs = { "limit" } },
                     quickfix       = { args = {},              kwargs = scope_kwargs },
                     reset          = { args = {},              kwargs = scope_kwargs },
                     select         = { args = {},              kwargs = use_kwargs },

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -378,6 +378,7 @@ function Grapple.statusline(opts)
     return statusline
 end
 
+---Unload tags for a give (scope) name or loaded scope (id)
 ---@param opts? { scope?: string, id?: string, notify?: boolean }
 ---@return string? error
 function Grapple.unload(opts)
@@ -389,10 +390,9 @@ function Grapple.unload(opts)
     local err = app:unload(opts)
     if err then
         if opts.notify then
-            return vim.notify(err, vim.log.levels.ERROR)
-        else
-            return err
+            vim.notify(err, vim.log.levels.ERROR)
         end
+        return err
     end
 
     if opts.notify then
@@ -413,10 +413,9 @@ function Grapple.reset(opts)
     local err = app:reset(opts)
     if err then
         if opts.notify then
-            return vim.notify(err, vim.log.levels.ERROR)
-        else
-            return err
+            vim.notify(err, vim.log.levels.ERROR)
         end
+        return err
     end
 
     if opts.notify then
@@ -424,14 +423,20 @@ function Grapple.reset(opts)
     end
 end
 
----@param opts { ttl: integer | string }
+---Prune
+---@param opts? { ttl?: integer | string, notify?: boolean }
 ---@return string[] | nil, string? error
 function Grapple.prune(opts)
     local App = require("grapple.app")
     local app = App.get()
 
-    local pruned_ids, err = app.tag_manager:prune(opts.ttl)
+    opts = opts or {}
+
+    local pruned_ids, err = app.tag_manager:prune(opts.until or app.settings.prune)
     if not pruned_ids then
+        if opts.notify then
+            vim.notify(err, vim.log.levels.ERROR)
+        end
         return nil, err
     end
 
@@ -679,6 +684,7 @@ function Grapple.initialize()
                     open_loaded    = { args = {},              kwargs = { "all" } },
                     open_scopes    = { args = {},              kwargs = {} },
                     open_tags      = { args = {},              kwargs = window_kwargs },
+                    prune          = { args = {},              kwargs = { "ttl" } },
                     quickfix       = { args = {},              kwargs = scope_kwargs },
                     reset          = { args = {},              kwargs = scope_kwargs },
                     select         = { args = {},              kwargs = use_kwargs },

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -41,12 +41,19 @@ local DEFAULT_SETTINGS = {
 
     ---A string of characters used for quick selecting in Grapple windows
     ---An empty string or false will disable quick select
-    ---@type string
+    ---@type string | boolean
     quick_select = "123456789",
 
     ---Default command to use when selecting a tag
     ---@type fun(path: string)
     command = vim.cmd.edit,
+
+    ---Time limit used for pruning unused scope (IDs). If a scope's save file
+    ---modified time exceeds this limit, then it will be deleted when a prune
+    ---requested. Can be an integer (in milliseconds) or a string time delta
+    ---(e.g. "30d" or "2h" or "15m")
+    ---@type integer | string
+    prune = "30d",
 
     ---@class grapple.scope_definition
     ---@field name string

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -50,7 +50,7 @@ local DEFAULT_SETTINGS = {
 
     ---Time limit used for pruning unused scope (IDs). If a scope's save file
     ---modified time exceeds this limit, then it will be deleted when a prune
-    ---requested. Can be an integer (in milliseconds) or a string time delta
+    ---requested. Can be an integer (in milliseconds) or a string time limit
     ---(e.g. "30d" or "2h" or "15m")
     ---@type integer | string
     prune = "30d",

--- a/lua/grapple/state.lua
+++ b/lua/grapple/state.lua
@@ -83,7 +83,7 @@ function State:remove(name)
 end
 
 ---@return string[] | nil pruned, string? error, string? error_kind
-function State:prune(ttl_msec)
+function State:prune(mtime_sec)
     local function current_time()
         local name = os.tmpname()
         local fd, err, err_kind = vim.loop.fs_open(name, "r", 438)
@@ -91,6 +91,7 @@ function State:prune(ttl_msec)
             return nil, err, err_kind
         end
 
+        ---@diagnostic disable-next-line: redefined-local
         local stat, err, err_kind = vim.loop.fs_fstat(fd)
         if not stat then
             return nil, err, err_kind
@@ -119,7 +120,7 @@ function State:prune(ttl_msec)
         end
 
         local elapsed_msec = now - stat.mtime.sec
-        if elapsed_msec > ttl_msec then
+        if elapsed_msec > mtime_sec then
             name = path_decode(name)
             name = string.gsub(name, "%.json", "")
             table.insert(pruned, path_decode(name))

--- a/lua/grapple/state.lua
+++ b/lua/grapple/state.lua
@@ -65,7 +65,7 @@ function State:list()
         end
 
         local name = file_name
-        name = path_decode(file_name)
+        name = path_decode(name)
         name = string.gsub(name, "%.json", "")
 
         table.insert(files, name)
@@ -97,7 +97,7 @@ function State:prune(limit_sec)
         local path = Path.join(self.save_dir, file_name)
 
         local name = file_name
-        name = path_decode(file_name)
+        name = path_decode(name)
         name = string.gsub(name, "%.json", "")
 
         ---@diagnostic disable-next-line: redefined-local

--- a/lua/grapple/tag_manager.lua
+++ b/lua/grapple/tag_manager.lua
@@ -152,37 +152,39 @@ function TagManager:reset(id)
     end
 end
 
----@param mtime integer | string
+---@param time_limit integer | string
 ---@return string[] | nil pruned, string? error
-function TagManager:prune(mtime)
+function TagManager:prune(time_limit)
     vim.validate({
-        mtime = { mtime, { "number", "string" } },
+        time_limit = { time_limit, { "number", "string" } },
     })
 
-    local mtime_msec
-    if type(mtime) == "number" then
-        mtime_msec = mtime
-    elseif type(mtime) == "string" then
-        local n, kind = string.match(mtime, "^(%d+)(%S)$")
+    local limit_sec
+    if type(time_limit) == "number" then
+        limit_sec = time_limit
+    elseif type(time_limit) == "string" then
+        local n, kind = string.match(time_limit, "^(%d+)(%S)$")
         if not n or not kind then
-            return nil, string.format("Could not parse time-to-live: %s", mtime)
+            return nil, string.format("Could not parse time limit: %s", time_limit)
         end
 
         n = assert(tonumber(n))
         if kind == "d" then
-            mtime_msec = n * 24 * 60 * 60 * 1000
+            limit_sec = n * 24 * 60 * 60
         elseif kind == "h" then
-            mtime_msec = n * 60 * 60 * 1000
+            limit_sec = n * 60 * 60
         elseif kind == "m" then
-            mtime_msec = n * 60 * 1000
+            limit_sec = n * 60
+        elseif kind == "s" then
+            limit_sec = n
         else
-            return nil, string.format("Invalid time-to-live kind: %s", kind)
+            return nil, string.format("Invalid time limit kind: %s", time_limit)
         end
     else
-        return nil, string.format("Invalid time-to-live: %s", vim.inspect(mtime))
+        return nil, string.format("Invalid time limit: %s", vim.inspect(time_limit))
     end
 
-    local pruned_ids, err = self.state:prune(mtime_msec)
+    local pruned_ids, err = self.state:prune(limit_sec)
     if not pruned_ids then
         return nil, err
     end

--- a/lua/grapple/tag_manager.lua
+++ b/lua/grapple/tag_manager.lua
@@ -152,37 +152,37 @@ function TagManager:reset(id)
     end
 end
 
----@param ttl integer | string
+---@param mtime integer | string
 ---@return string[] | nil pruned, string? error
-function TagManager:prune(ttl)
+function TagManager:prune(mtime)
     vim.validate({
-        ttl = { ttl, { "number", "string" } },
+        mtime = { mtime, { "number", "string" } },
     })
 
-    local ttl_msec
-    if type(ttl) == "number" then
-        ttl_msec = ttl
-    elseif type(ttl) == "string" then
-        local n, kind = string.match(ttl, "^(%d+)(%S)$")
+    local mtime_msec
+    if type(mtime) == "number" then
+        mtime_msec = mtime
+    elseif type(mtime) == "string" then
+        local n, kind = string.match(mtime, "^(%d+)(%S)$")
         if not n or not kind then
-            return nil, string.format("Could not parse time-to-live: %s", ttl)
+            return nil, string.format("Could not parse time-to-live: %s", mtime)
         end
 
         n = assert(tonumber(n))
         if kind == "d" then
-            ttl_msec = n * 24 * 60 * 60 * 1000
+            mtime_msec = n * 24 * 60 * 60 * 1000
         elseif kind == "h" then
-            ttl_msec = n * 60 * 60 * 1000
+            mtime_msec = n * 60 * 60 * 1000
         elseif kind == "m" then
-            ttl_msec = n * 60 * 1000
+            mtime_msec = n * 60 * 1000
         else
             return nil, string.format("Invalid time-to-live kind: %s", kind)
         end
     else
-        return nil, string.format("Invalid time-to-live: %s", vim.inspect(ttl))
+        return nil, string.format("Invalid time-to-live: %s", vim.inspect(mtime))
     end
 
-    local pruned_ids, err = self.state:prune(ttl_msec)
+    local pruned_ids, err = self.state:prune(mtime_msec)
     if not pruned_ids then
         return nil, err
     end


### PR DESCRIPTION
### Context

Tag containers all live as their own JSON file. This can lead to an large number of orphaned files if a user does not clean them up every so often (through the Loaded Scopes window). This adds an automated way to clean up unused files so users don't have to worry about it.

Todo:
- [x] Update README
- [x] Update `:Grapple` completion
- [x] Handle `{ notify = true }`
- [x] Add  (`prune = "30d`)

### Changes

- Add `Grapple.prune`
- Add settings `prune`