### PR TITLE
refactor: soft deprecate `Grapple.cycle` for `Grapple.cycle_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Note, these examples assume you are using the [lazy.nvim](https://github.com/fol
     keys = {
         { "<leader>m", "<cmd>Grapple toggle<cr>", desc = "Grapple toggle tag" },
         { "<leader>M", "<cmd>Grapple toggle_tags<cr>", desc = "Grapple open tags window" },
+        { "<leader>n", "<cmd>Grapple cycle_tags next<cr>", desc = "Grapple cycle next tag" },
+        { "<leader>p", "<cmd>Grapple cycle_tags prev<cr>", desc = "Grapple cycle previous tag" },
     },
 },
 ```
@@ -150,8 +152,8 @@ Example configuration similar to [harpoon.nvim](https://github.com/ThePrimeagen/
         { "<c-n>", "<cmd>Grapple select index=3<cr>", desc = "Select third tag" },
         { "<c-s>", "<cmd>Grapple select index=4<cr>", desc = "Select fourth tag" },
 
-        { "<c-s-p>", "<cmd>Grapple cycle backward<cr>", desc = "Go to previous tag" },
-        { "<c-s-n>", "<cmd>Grapple cycle forward<cr>", desc = "Go to next tag" },
+        { "<c-s-n>", "<cmd>Grapple cycle_tags next<cr>", desc = "Go to next tag" },
+        { "<c-s-p>", "<cmd>Grapple cycle_tags prev<cr>", desc = "Go to previous tag" },
     },
 },
 ```
@@ -178,8 +180,8 @@ Example configuration similar to [arrow.nvim](https://github.com/otavioschwanck/
         { ";", "<cmd>Grapple toggle_tags<cr>", desc = "Toggle tags menu" },
 
         { "<c-s>", "<cmd>Grapple toggle<cr>", desc = "Toggle tag" },
-        { "H", "<cmd>Grapple cycle forward<cr>", desc = "Go to next tag" },
-        { "L", "<cmd>Grapple cycle backward<cr>", desc = "Go to previous tag" },
+        { "H", "<cmd>Grapple cycle_tags next<cr>", desc = "Go to next tag" },
+        { "L", "<cmd>Grapple cycle_tags prev<cr>", desc = "Go to previous tag" },
     },
 },
 ```
@@ -304,13 +306,13 @@ In general, the API is as follows:
 Where `opts` in the user command is a list of `value` arguments and `key=value` keyword arguments. For example,
 
 ```vim
-:Grapple cycle forward scope=cwd
+:Grapple cycle_tags next scope=cwd
 ```
 
 Has the equivalent form
 
 ```lua
-require("grapple").cycle("forward", { scope = "cwd" })
+require("grapple").cycle_tags("next", { scope = "cwd" })
 ```
 
 ### Grapple API
@@ -419,19 +421,15 @@ require("grapple").select({ index = 3 })
 
 </details>
 
-#### `Grapple.cycle`
+#### `Grapple.cycle_tags`
 
 Cycle through and select the next or previous available tag for a given scope.
 
-**API**:
-
-- `require("grapple").cycle(direction, opts)`
-- `require("grapple").cycle_backward(opts)`
-- `require("grapple").cycle_forward(opts)`
+**API**: `require("grapple").cycle_tags(direction, opts)`
 
 Where:
 
-- **`direction`**: `"backward"` | `"forward"`
+- **`direction`**: `"next"` | `"prev"`
 - **`opts?`**: [`grapple.options`](#grappleoptions) (one of)
 
 **Note**: Starting tag is searched based on one of (in order): `index`, `name`, `path`, `buffer`
@@ -441,10 +439,10 @@ Where:
 
 ```lua
 -- Cycle to the previous tagged file
-require("grapple").cycle_backward()
+require("grapple").cycle_tags("next")
 
 -- Cycle to the next tagged file
-require("grapple").cycle_forward()
+require("grapple").cycle_tags("prev")
 ```
 
 </details>

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -196,21 +196,26 @@ function Grapple.quickfix(opts)
     end
 end
 
+---@param current_index? integer
+---@param direction "next" | "prev"
+---@param length integer
+---@return integer
 local function next_index(current_index, direction, length)
     -- Fancy maths to get the next index for a given direction
     -- 1. Change to 0-based indexing
     -- 2. Perform index % container length, being careful of negative values
     -- 3. Change back to 1-based indexing
     -- stylua: ignore
-    local index = (
+    current_index = (
         current_index
         or direction == "next" and length
         or direction == "prev" and 1
     ) - 1
-    local next_direction = direction == "next" and 1 or -1
-    local next_index = math.fmod(index + next_direction + length, length) + 1
 
-    return next_index
+    local next_inc = direction == "next" and 1 or -1
+    local next_idx = math.fmod(current_index + next_inc + length, length) + 1
+
+    return next_idx
 end
 
 ---Select the next available tag for a given scope

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -213,12 +213,6 @@ local function next_index(current_index, direction, length)
     return next_index
 end
 
-local function format_message(message)
-    message = vim.trim(message)
-    message = string.gsub(message, "\n%s+", "\n")
-    return message
-end
-
 ---Select the next available tag for a given scope
 ---By default, uses the current scope
 ---@deprecated Soft-deprecated in favour of Grapple.cycle_tags

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -256,7 +256,12 @@ function Grapple.cycle_tags(direction, opts)
     -- stylua: ignore
     direction = direction == "forward" and "next"
         or direction == "backward" and "prev"
+        or direction == "previous" and "prev"
         or direction
+
+    if not vim.tbl_contains({ "next", "prev" }, direction) then
+        return vim.notify(string.format("invalid direction: %s", direction), vim.log.levels.ERROR)
+    end
 
     app:enter_without_save(opts.scope, function(container)
         if container:is_empty() then
@@ -745,7 +750,7 @@ function Grapple.initialize()
                 -- Lookup table of arguments and their known values
                 local argument_lookup = {
                     all = { "true", "false" },
-                    direction = { "forward", "backward" },
+                    direction = { "next", "prev" },
                     scope = Util.sort(vim.tbl_keys(app.scope_manager.scopes), Util.as_lower),
                     style = Util.sort(vim.tbl_keys(app.settings.styles), Util.as_lower),
                 }


### PR DESCRIPTION
### Context

Preparing to add cycling for both scopes and loaded scopes. The `Grapple.cycle` doesn't generalize well without a breaking change. For this matter, simply move away from `Grapple.cycle` and `Grapple.cycle_{forward|backward` to `Grapple.cycle_tags`.

### Changes

- Soft deprecate `Grapple cycle {forward|backward}`. Defer to `Grapple cycle_tags {next|prev}`
- Soft deprecate `Grapple cycle_forward`. Defer to `Grapple cycle_tags next`
- Soft deprecate `Grapple cycle_backward`. Defer to `Grapple cycle_tags prev`
- Soft change verbiage from (`forward`, `backward`) to (`next`, `prev`)