### PR TITLE
feat: Statusline caching and custom functions

### DIFF
--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -320,12 +320,14 @@ function Grapple.find(opts)
     return tag, nil
 end
 
+-- TODO: Also try to incorporate in grapple.statusline
 ---Return if a tag exists. Used for statusline components
 ---@param opts? grapple.options
 function Grapple.exists(opts)
     return Grapple.find(opts) ~= nil
 end
 
+-- TODO: Also try to incorporate in grapple.statusline
 ---Return the name or index of a tag. Used for statusline components
 ---@param opts? grapple.options
 ---@return string | integer | nil
@@ -375,45 +377,52 @@ function Grapple.tags(opts)
 end
 
 ---Return a formatted string to be displayed on the statusline
----@param opts grapple.statusline.options
----@return string | nil
-function Grapple.statusline(opts)
-    local App = require("grapple.app")
-    local app = App.get()
-
-    opts = vim.tbl_deep_extend("keep", opts or {}, app.settings.statusline)
-
-    local tags, err = Grapple.tags()
-    if not tags then
-        return err
-    end
-
-    local current = Grapple.find({ buffer = 0 })
-
-    local quick_select = app.settings:quick_select()
-    local output = {}
-
-    for i, tag in ipairs(tags) do
-        -- stylua: ignore
-        local tag_str = tag.name and tag.name
-            or quick_select[i] and quick_select[i]
-            or i
-
-        local tag_fmt = opts.inactive
-        if current and current.path == tag.path then
-            tag_fmt = opts.active
-        end
-
-        table.insert(output, string.format(tag_fmt, tag_str))
-    end
-
-    local statusline = table.concat(output)
-    if opts.include_icon then
-        statusline = string.format("%s %s", opts.icon, statusline)
-    end
-
-    return statusline
+function Grapple.statusline()
+    local line = require("grapple.statusline").get()
+    return line:format()
 end
+
+-- TODO: Keep for reference, remove later
+-- ---Return a formatted string to be displayed on the statusline
+-- ---@param opts grapple.statusline.options
+-- ---@return string | nil
+-- function Grapple.statusline(opts)
+--     local App = require("grapple.app")
+--     local app = App.get()
+--
+--     opts = vim.tbl_deep_extend("keep", opts or {}, app.settings.statusline)
+--
+--     local tags, err = Grapple.tags()
+--     if not tags then
+--         return err
+--     end
+--
+--     local current = Grapple.find({ buffer = 0 })
+--
+--     local quick_select = app.settings:quick_select()
+--     local output = {}
+--
+--     for i, tag in ipairs(tags) do
+--         -- stylua: ignore
+--         local tag_str = tag.name and tag.name
+--             or quick_select[i] and quick_select[i]
+--             or i
+--
+--         local tag_fmt = opts.inactive
+--         if current and current.path == tag.path then
+--             tag_fmt = opts.active
+--         end
+--
+--         table.insert(output, string.format(tag_fmt, tag_str))
+--     end
+--
+--     local statusline = table.concat(output)
+--     if opts.include_icon then
+--         statusline = string.format("%s %s", opts.icon, statusline)
+--     end
+--
+--     return statusline
+-- end
 
 ---Unload tags for a give (scope) name or loaded scope (id)
 ---@param opts? { scope?: string, id?: string, notify?: boolean }

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -320,14 +320,12 @@ function Grapple.find(opts)
     return tag, nil
 end
 
--- TODO: Also try to incorporate in grapple.statusline
 ---Return if a tag exists. Used for statusline components
 ---@param opts? grapple.options
 function Grapple.exists(opts)
     return Grapple.find(opts) ~= nil
 end
 
--- TODO: Also try to incorporate in grapple.statusline
 ---Return the name or index of a tag. Used for statusline components
 ---@param opts? grapple.options
 ---@return string | integer | nil
@@ -377,52 +375,11 @@ function Grapple.tags(opts)
 end
 
 ---Return a formatted string to be displayed on the statusline
+---@return string
 function Grapple.statusline()
     local line = require("grapple.statusline").get()
     return line:format()
 end
-
--- TODO: Keep for reference, remove later
--- ---Return a formatted string to be displayed on the statusline
--- ---@param opts grapple.statusline.options
--- ---@return string | nil
--- function Grapple.statusline(opts)
---     local App = require("grapple.app")
---     local app = App.get()
---
---     opts = vim.tbl_deep_extend("keep", opts or {}, app.settings.statusline)
---
---     local tags, err = Grapple.tags()
---     if not tags then
---         return err
---     end
---
---     local current = Grapple.find({ buffer = 0 })
---
---     local quick_select = app.settings:quick_select()
---     local output = {}
---
---     for i, tag in ipairs(tags) do
---         -- stylua: ignore
---         local tag_str = tag.name and tag.name
---             or quick_select[i] and quick_select[i]
---             or i
---
---         local tag_fmt = opts.inactive
---         if current and current.path == tag.path then
---             tag_fmt = opts.active
---         end
---
---         table.insert(output, string.format(tag_fmt, tag_str))
---     end
---
---     local statusline = table.concat(output)
---     if opts.include_icon then
---         statusline = string.format("%s %s", opts.icon, statusline)
---     end
---
---     return statusline
--- end
 
 ---Unload tags for a give (scope) name or loaded scope (id)
 ---@param opts? { scope?: string, id?: string, notify?: boolean }

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -452,53 +452,33 @@ local DEFAULT_SETTINGS = {
         inactive = " %s ",
         active = "[%s]",
 
-        -- Mostly for lualine integration. Lualine will automatically prepend
-        -- the icon to the returned output
+        -- Mostly for lualine integration. The Lualine "grapple" component
+        -- automatically prepends the icon to the returned output
+        -- In order to prevent the *formatter* from prepending the icon
+        -- when using the "grapple" component, the component sets include_icon to false
         include_icon = true,
 
-        -- A default statusline implementation
-        ---@type grapple.formatter
-        formatter = function(opts, data)
-            if #data.tags == 0 then
-                return ""
-            end
+        -- The builtin formatter to be used in require("grapple").statusline()
+        -- default: current lualine example 1
+        -- short: current lualine example 2 ( without the need to setup lualine in a different way )
+        ---@type "default" | "short"
+        builtin_formatter = "default",
 
-            local output = {}
-            local qs = data.quick_select
-            for i, tag in ipairs(data.tags) do
-                local tag_str = tag.name and tag.name or qs[i] and qs[i] or i
-                local tag_fmt = opts.inactive
-                if data.current and data.current.path == tag.path then
-                    tag_fmt = opts.active
-                end
-                table.insert(output, string.format(tag_fmt, tag_str))
-            end
+        -- Override: Use a custom statusline implementation:
+        -- ---@type grapple.formatter
+        -- formatter = function(opts, data) return "" end,
+        formatter = nil,
 
-            local statusline = table.concat(output)
-            if opts.include_icon then
-                statusline = string.format("%s %s", opts.icon, statusline)
-            end
+        ---@type fun(): fun() | nil
+        on_event_factory = function()
+            -- use the builtin support for lualine, mini.statusline, heirline and nvchad:
+            return nil
 
-            return statusline
+            -- -- or: Return a custom function, notifying a consumer of the line
+            -- return function()
+            --     -- Refresh consumer....
+            -- end
         end,
-
-        -- NOTE: The on_update function uses "lualine" by default if present.
-        -- Users should override this function when another statusline is used.
-        ---@type fun(): nil
-        on_update = function()
-            local ok, Lualine = pcall(require, "lualine")
-            if ok then
-                Lualine.refresh()
-            end
-        end,
-        -- ---@type fun(): nil
-        -- on_update = function() -- echasnovski/mini.statusline
-        --     vim.wo.statusline = "%{%v:lua.MiniStatusline.active()%}"
-        -- end,
-        -- ---@type fun(): nil
-        -- on_update = function() -- rebelot/heirline.nvim
-        --     vim.cmd.redrawstatus()
-        -- end,
     },
 }
 

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -455,6 +455,50 @@ local DEFAULT_SETTINGS = {
         -- Mostly for lualine integration. Lualine will automatically prepend
         -- the icon to the returned output
         include_icon = true,
+
+        -- A default statusline implementation
+        ---@type grapple.formatter
+        formatter = function(opts, data)
+            if #data.tags == 0 then
+                return ""
+            end
+
+            local output = {}
+            local qs = data.quick_select
+            for i, tag in ipairs(data.tags) do
+                local tag_str = tag.name and tag.name or qs[i] and qs[i] or i
+                local tag_fmt = opts.inactive
+                if data.current and data.current.path == tag.path then
+                    tag_fmt = opts.active
+                end
+                table.insert(output, string.format(tag_fmt, tag_str))
+            end
+
+            local statusline = table.concat(output)
+            if opts.include_icon then
+                statusline = string.format("%s %s", opts.icon, statusline)
+            end
+
+            return statusline
+        end,
+
+        -- NOTE: The on_update function uses "lualine" by default if present.
+        -- Users should override this function when another statusline is used.
+        ---@type fun(): nil
+        on_update = function()
+            local ok, Lualine = pcall(require, "lualine")
+            if ok then
+                Lualine.refresh()
+            end
+        end,
+        -- ---@type fun(): nil
+        -- on_update = function() -- echasnovski/mini.statusline
+        --     vim.wo.statusline = "%{%v:lua.MiniStatusline.active()%}"
+        -- end,
+        -- ---@type fun(): nil
+        -- on_update = function() -- rebelot/heirline.nvim
+        --     vim.cmd.redrawstatus()
+        -- end,
     },
 }
 

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -454,13 +454,9 @@ local DEFAULT_SETTINGS = {
 
         -- Mostly for lualine integration. The Lualine "grapple" component
         -- automatically prepends the icon to the returned output
-        -- In order to prevent the *formatter* from prepending the icon
-        -- when using the "grapple" component, the component sets include_icon to false
         include_icon = true,
 
-        -- The builtin formatter to be used in require("grapple").statusline()
-        -- default: current lualine example 1
-        -- short: current lualine example 2 ( without the need to setup lualine in a different way )
+        -- The builtin formatter to be used
         ---@type "default" | "short"
         builtin_formatter = "default",
 
@@ -471,10 +467,10 @@ local DEFAULT_SETTINGS = {
 
         ---@type fun(): fun() | nil
         on_event_factory = function()
-            -- use the builtin support for lualine, mini.statusline, heirline and nvchad:
+            -- Use the builtin support for lualine, mini.statusline, heirline or nvchad:
             return nil
 
-            -- -- or: Return a custom function, notifying a consumer of the line
+            -- -- Or: Return a custom function, notifying a consumer of the line
             -- return function()
             --     -- Refresh consumer....
             -- end

--- a/lua/grapple/statusline.lua
+++ b/lua/grapple/statusline.lua
@@ -1,0 +1,143 @@
+--[[
+Remarks:
+1. The statusline is opt-in: Can't be builtin to the app
+2. Lualine: The statusline is far more responsive when using the on_update function!
+--]]
+
+local Grapple = require("grapple")
+
+-- The data a formatter function uses to built the line
+---@class grapple.statuslinedata
+---@field scope_name string
+---@field tags grapple.tag[]
+---@field current? grapple.tag
+---@field quick_select string[]
+
+--The signature of a formatter function
+---@alias grapple.formatter fun(opts: grapple.statusline.options, data: grapple.statuslinedata): string
+
+---@class grapple.statusline
+---@field cached_line string
+---@field current_scope string
+---@field formatter grapple.formatter
+---@field on_update function
+---@field opts grapple.statusline.options
+---@field quick_select string[]
+local Statusline = {}
+Statusline.__index = Statusline
+
+---A global instance of the statusline
+---@type grapple.statusline
+local statusline
+
+local STATUSLINE_GROUP = vim.api.nvim_create_augroup("GrappleStatusline", { clear = true })
+
+function Statusline.get()
+    if statusline then
+        return statusline
+    end
+
+    local app = require("grapple.app").get()
+    statusline = Statusline:new(app)
+    statusline:initialize()
+
+    return statusline
+end
+
+---@param app grapple.app
+---@return grapple.statusline
+function Statusline:new(app)
+    local se = app.settings
+    return setmetatable({ -- apply defaults
+        cached_line = "",
+        current_scope = se.scope, -- updated on grapple.use_scope
+        formatter = se.statusline.formatter,
+        on_update = se.statusline.on_update,
+        opts = se.statusline,
+        quick_select = se:quick_select(), -- a constant
+    }, self)
+end
+
+function Statusline:initialize()
+    self:subscribe_to_events()
+    self:subscribe_to_api() -- TODO: GrappleUpdate crashes!
+    self:update_cached()
+end
+
+function Statusline:subscribe_to_events()
+    vim.api.nvim_create_autocmd({ "BufEnter" }, {
+        group = STATUSLINE_GROUP,
+        pattern = "*",
+        callback = function()
+            self:update()
+        end,
+    })
+    -- vim.api.nvim_create_autocmd({ "User" }, {
+    --     group = STATUSLINE_GROUP,
+    --     pattern = "GrappleScopeChanged",
+    --     callback = function()
+    --         self:update()
+    --     end,
+    -- })
+    -- vim.api.nvim_create_autocmd({ "User" },
+    --     group = STATUSLINE_GROUP,
+    --     nested = false,
+    --     pattern = "GrappleUpdate",
+    --     callback = function()
+    --         self:update()
+    --     end,
+    -- })
+end
+
+-- Decorate Grapple's api in order to update internally
+function Statusline:subscribe_to_api()
+    local function decorate(org_cmd)
+        return function(...)
+            org_cmd(...) -- Run the api function
+            self:update() -- and update internally
+        end
+    end
+
+    Grapple.toggle = decorate(Grapple.toggle)
+    Grapple.tag = decorate(Grapple.tag)
+    Grapple.untag = decorate(Grapple.untag)
+    Grapple.reset = decorate(Grapple.reset)
+
+    local grapple_use_scope = Grapple.use_scope
+    ---@diagnostic disable-next-line: duplicate-set-field
+    Grapple.use_scope = function(scope_name)
+        grapple_use_scope(scope_name)
+        self.current_scope = scope_name
+        self:update()
+    end
+end
+
+-- Update the cache
+function Statusline:update_cached()
+    local tags, _ = Grapple.tags() -- using the current scope
+
+    ----@type grapple.statuslinedata
+    local data = {
+        current = Grapple.find({ buffer = 0 }),
+        scope_name = self.current_scope,
+        tags = tags or {},
+        quick_select = self.quick_select,
+    }
+
+    self.cached_line = self.formatter(self.opts, data)
+end
+
+-- Update the cache and notify consumers
+function Statusline:update()
+    self:update_cached()
+    self:on_update()
+end
+
+-- The function to be used by consumers
+-- Returns a cached statusline
+---@return string
+function Statusline:format()
+    return self.cached_line
+end
+
+return Statusline

--- a/lua/grapple/statusline.lua
+++ b/lua/grapple/statusline.lua
@@ -1,17 +1,3 @@
---[[
-Remarks:
-The statusline is opt-in: Can't be builtin to the app
-Lualine: The statusline is far more responsive when using the on_event function!
-Perhaps: 
-  The default formatter: Add empty_slots, more_marks and scope_name
-  See test case "custom formatter"
-Test with mini.statusline
-
- TODO: public/non_public: Add "_" to names?
- TODO: Remove the second statusline example from the docs, in favor of builtin_formatter = "short"
- TODO: The docs...
---]]
-
 local Grapple = require("grapple")
 
 -- The data a formatter function uses to built the line
@@ -107,7 +93,7 @@ end
 
 function Statusline:initialize()
     self:subscribe_to_events()
-    self:subscribe_to_api() -- TODO: GrappleUpdate crashes!
+    self:subscribe_to_api()
     self:update_cached()
 end
 
@@ -119,21 +105,6 @@ function Statusline:subscribe_to_events()
             self:update()
         end,
     })
-    -- vim.api.nvim_create_autocmd({ "User" }, {
-    --     group = STATUSLINE_GROUP,
-    --     pattern = "GrappleScopeChanged",
-    --     callback = function()
-    --         self:update()
-    --     end,
-    -- })
-    -- vim.api.nvim_create_autocmd({ "User" },
-    --     group = STATUSLINE_GROUP,
-    --     nested = false,
-    --     pattern = "GrappleUpdate",
-    --     callback = function()
-    --         self:update()
-    --     end,
-    -- })
 end
 
 -- Decorate Grapple's api in order to update internally

--- a/lua/lualine/components/grapple.lua
+++ b/lua/lualine/components/grapple.lua
@@ -7,34 +7,6 @@ function Component:init(opts)
     Component.super:init(opts)
 end
 
--- TODO: Keep for reference, remove later
--- ---@return string | nil
--- function Component:update_status()
---     if package.loaded["grapple"] == nil then
---         return
---     end
---
---     local ok, grapple = pcall(require, "grapple")
---     if not ok then
---         return
---     end
---
---     -- Lazyily add statusline options to the component
---     if not self.options.icon or not self.options.active or not self.options.inactive then
---         local App = require("grapple.app")
---         local app = App.get()
---
---         -- stylua: ignore
---         self.options = vim.tbl_deep_extend("keep",
---             self.options,
---             { include_icon = false },
---             app.settings.statusline
---         )
---     end
---
---     return grapple.statusline(self.options)
--- end
-
 ---@return string | nil
 function Component:update_status()
     if package.loaded["grapple"] == nil then
@@ -51,7 +23,7 @@ function Component:update_status()
         local app = require("grapple.app").get()
         app.settings.statusline["include_icon"] = false -- lualine handles the icon
 
-        -- No icon for the short formatter:
+        -- The "short" formatter should not display an icon:
         if app.settings.statusline.builtin_formatter == "short" then
             self.options["icons_enabled"] = false
         end

--- a/lua/lualine/components/grapple.lua
+++ b/lua/lualine/components/grapple.lua
@@ -7,6 +7,34 @@ function Component:init(opts)
     Component.super:init(opts)
 end
 
+-- TODO: Keep for reference, remove later
+-- ---@return string | nil
+-- function Component:update_status()
+--     if package.loaded["grapple"] == nil then
+--         return
+--     end
+--
+--     local ok, grapple = pcall(require, "grapple")
+--     if not ok then
+--         return
+--     end
+--
+--     -- Lazyily add statusline options to the component
+--     if not self.options.icon or not self.options.active or not self.options.inactive then
+--         local App = require("grapple.app")
+--         local app = App.get()
+--
+--         -- stylua: ignore
+--         self.options = vim.tbl_deep_extend("keep",
+--             self.options,
+--             { include_icon = false },
+--             app.settings.statusline
+--         )
+--     end
+--
+--     return grapple.statusline(self.options)
+-- end
+
 ---@return string | nil
 function Component:update_status()
     if package.loaded["grapple"] == nil then
@@ -22,16 +50,15 @@ function Component:update_status()
     if not self.options.icon or not self.options.active or not self.options.inactive then
         local App = require("grapple.app")
         local app = App.get()
+        app.settings.statusline["include_icon"] = false -- lualine handles the icon
 
         -- stylua: ignore
-        self.options = vim.tbl_deep_extend("keep",
+        self.options = vim.tbl_deep_extend("keep", -- options for lualine
             self.options,
-            { include_icon = false },
             app.settings.statusline
         )
     end
-
-    return grapple.statusline(self.options)
+    return grapple.statusline()
 end
 
 return Component

--- a/lua/lualine/components/grapple.lua
+++ b/lua/lualine/components/grapple.lua
@@ -48,12 +48,16 @@ function Component:update_status()
 
     -- Lazyily add statusline options to the component
     if not self.options.icon or not self.options.active or not self.options.inactive then
-        local App = require("grapple.app")
-        local app = App.get()
+        local app = require("grapple.app").get()
         app.settings.statusline["include_icon"] = false -- lualine handles the icon
 
-        -- stylua: ignore
-        self.options = vim.tbl_deep_extend("keep", -- options for lualine
+        -- No icon for the short formatter:
+        if app.settings.statusline.builtin_formatter == "short" then
+            self.options["icons_enabled"] = false
+        end
+
+        self.options = vim.tbl_deep_extend(
+            "keep", -- options for lualine
             self.options,
             app.settings.statusline
         )

--- a/tests/grapple/statusline_spec.lua
+++ b/tests/grapple/statusline_spec.lua
@@ -1,20 +1,17 @@
--- TODO: Test include_icon
--- TODO: Test tag with name
--- TODO: Test tag and quicklit
--- TODO: Test is_buffer_tagged method
-
 ---@diagnostic disable-next-line: undefined-field
 local same = assert.same
 local icon = "󰛢"
 
 local function unload()
     package.loaded["grapple"] = nil
+    package.loaded["grapple.app"] = nil
     package.loaded["grapple.statusline"] = nil
+    package.loaded["grapple.settings"] = nil
     require("grapple").reset()
 end
 local function add(buffer_names, grapple)
     for _, name in ipairs(buffer_names) do
-        vim.cmd("edit " .. name)
+        vim.cmd.edit(name)
         grapple.toggle()
     end
 end
@@ -31,14 +28,50 @@ describe("Statusline .format default", function()
     it("is correct having 5 tags, current buffer is 2", function()
         local Grapple = require("grapple")
         add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
-        vim.cmd("edit " .. "bar")
+        vim.cmd.edit("bar")
         same(icon .. "  1 [2] 3  4  5 ", Grapple.statusline())
     end)
     it("is correct having 5 tags, current buffer is not tagged", function()
         local Grapple = require("grapple")
         add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
-        vim.cmd("edit " .. "abc")
+        vim.cmd.edit("abc")
         same(icon .. "  1  2  3  4  5 ", Grapple.statusline())
+    end)
+    it("is correct when a tag is untagged", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        add({ "foo" }, Grapple) -- toggle
+        same(icon .. "  1  2  3  4 ", Grapple.statusline())
+    end)
+    it("displays the name of a tag", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar" }, Grapple)
+        vim.cmd.edit("foo")
+        Grapple.tag({ name = "foo" })
+        same(icon .. " [foo] 2 ", Grapple.statusline())
+    end)
+end)
+
+describe("Statusline .format default", function()
+    before_each(unload)
+    it("does not display an icon when option include_icon = false", function()
+        local Grapple = require("grapple")
+        Grapple.setup({ statusline = { include_icon = false } })
+        add({ "foo", "bar" }, Grapple)
+        same(" 1 [2]", Grapple.statusline())
+    end)
+    it("correctly displays quickselect characters", function()
+        local Grapple = require("grapple")
+        Grapple.setup({ quick_select = "jklh56789" })
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        vim.cmd.edit("bar")
+        same(icon .. "  j [k] l  h  5 ", Grapple.statusline())
+    end)
+    it("correctly skips displaying quickselect characters", function()
+        local Grapple = require("grapple")
+        Grapple.setup({ quick_select = false })
+        add({ "foo", "bar" }, Grapple)
+        same(icon .. "  1 [2]", Grapple.statusline())
     end)
 end)
 
@@ -58,14 +91,27 @@ describe("Statusline .format short", function()
     it("is correct having 5 tags, current buffer is 2", function()
         local Grapple = require("grapple")
         add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
-        vim.cmd("edit " .. "bar")
+        vim.cmd.edit("bar")
         same("2", Grapple.statusline())
     end)
     it("is correct having 5 tags, current buffer is not tagged", function()
         local Grapple = require("grapple")
         add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
-        vim.cmd("edit " .. "abc")
+        vim.cmd.edit("abc")
         same("", Grapple.statusline())
+    end)
+    it("is correct when a tag is untagged", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        add({ "foo" }, Grapple)
+        same("", Grapple.statusline())
+    end)
+    it("displays the name of a tag", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar" }, Grapple)
+        vim.cmd.edit("foo")
+        Grapple.tag({ name = "foo" })
+        same("foo", Grapple.statusline())
     end)
 end)
 
@@ -77,16 +123,14 @@ local function custom(opts_in, data)
         active = "[%s]",
         empty_slot = "·", -- #slots > #tags, middledot
         more_marks_indicator = "…", -- #slots < #tags, horizontal elipsis
-        more_marks_active_indicator = "[…]",
     }
     if data.scope_name == "git" then
         data.scope_name = ""
     end
-    local prefix = string.format("%s%s%s", opts_in.icon, data.scope_name == "" and "" or " ", data.scope_name)
 
-    -- build slots:
-    local status = {}
+    local status = {} -- build slots:
     local max_tags = #data.tags
+    local current_path = data.current and data.current.path or nil
     for i = 1, opts.max_slots do
         local tag_fmt = opts.inactive
         local tag_str = "" .. i
@@ -94,28 +138,30 @@ local function custom(opts_in, data)
             tag_str = opts.empty_slot
         else
             local tag = data.tags[i]
-            if data.current and data.current.path == tag.path then
+            if current_path == tag.path then
                 tag_fmt = opts.active
             end
         end
         table.insert(status, string.format(tag_fmt, tag_str))
     end
-    -- extra slot:
-    if max_tags > opts.max_slots then -- more marks then...
-        local ind = opts.more_marks_indicator
-        for i = opts.max_slots + 1, max_tags do
-            local tag = data.tags[i]
-            if data.current and data.current.path == tag.path then
-                ind = opts.more_marks_active_indicator
-                break
+    if max_tags > opts.max_slots then -- more marks then... One indicator
+        local tag_fmt = opts.inactive
+        local tag_str = opts.more_marks_indicator
+        if current_path then
+            for i = opts.max_slots + 1, max_tags do
+                local tag = data.tags[i]
+                if current_path == tag.path then
+                    tag_fmt = opts.active
+                    break
+                end
             end
         end
-        table.insert(status, ind)
+        table.insert(status, string.format(tag_fmt, tag_str))
     end
 
+    local prefix = string.format("%s%s%s", opts_in.icon, data.scope_name == "" and "" or " ", data.scope_name)
     return prefix .. " " .. table.concat(status)
 end
-
 describe("Statusline .format custom formatter", function()
     before_each(function()
         unload()
@@ -136,7 +182,7 @@ describe("Statusline .format custom formatter", function()
     it("is correct having 5 tags, current buffer is 2", function()
         local Grapple = require("grapple")
         add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
-        vim.cmd("edit " .. "bar")
+        vim.cmd.edit("bar")
         same(icon .. " 1[2]34…", Grapple.statusline())
     end)
     it("is correct having 5 tags, current buffer is last", function()
@@ -147,7 +193,19 @@ describe("Statusline .format custom formatter", function()
     it("is correct having 5 tags, current buffer is not tagged", function()
         local Grapple = require("grapple")
         add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
-        vim.cmd("edit " .. "abc")
+        vim.cmd.edit("abc")
         same(icon .. " 1234…", Grapple.statusline())
+    end)
+end)
+
+describe("Api is_current_buffer_tagged", function()
+    before_each(unload)
+    it("correctly reports if the current buffer is tagged", function()
+        local Grapple = require("grapple")
+        local line = require("grapple.statusline").get()
+        add({ "foo" }, Grapple)
+        same(true, line:is_current_buffer_tagged())
+        add({ "foo" }, Grapple)
+        same(false, line:is_current_buffer_tagged())
     end)
 end)

--- a/tests/grapple/statusline_spec.lua
+++ b/tests/grapple/statusline_spec.lua
@@ -1,0 +1,13 @@
+local Grapple = require("grapple")
+
+---@diagnostic disable-next-line: undefined-field
+local same = assert.same
+-- local icon = "󰛢"
+
+describe("Statusline", function()
+    describe(".format", function()
+        it("has correct default behaviour", function()
+            same("", Grapple.statusline())
+        end)
+    end)
+end)

--- a/tests/grapple/statusline_spec.lua
+++ b/tests/grapple/statusline_spec.lua
@@ -1,13 +1,153 @@
-local Grapple = require("grapple")
+-- TODO: Test include_icon
+-- TODO: Test tag with name
+-- TODO: Test tag and quicklit
+-- TODO: Test is_buffer_tagged method
 
 ---@diagnostic disable-next-line: undefined-field
 local same = assert.same
--- local icon = "󰛢"
+local icon = "󰛢"
 
-describe("Statusline", function()
-    describe(".format", function()
-        it("has correct default behaviour", function()
-            same("", Grapple.statusline())
-        end)
+local function unload()
+    package.loaded["grapple"] = nil
+    package.loaded["grapple.statusline"] = nil
+    require("grapple").reset()
+end
+local function add(buffer_names, grapple)
+    for _, name in ipairs(buffer_names) do
+        vim.cmd("edit " .. name)
+        grapple.toggle()
+    end
+end
+describe("Statusline .format default", function()
+    before_each(unload)
+    it("is correct without tags", function()
+        same("", require("grapple").statusline())
+    end)
+    it("is correct having 2 tags, current buffer is last", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar" }, Grapple)
+        same(icon .. "  1 [2]", Grapple.statusline())
+    end)
+    it("is correct having 5 tags, current buffer is 2", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        vim.cmd("edit " .. "bar")
+        same(icon .. "  1 [2] 3  4  5 ", Grapple.statusline())
+    end)
+    it("is correct having 5 tags, current buffer is not tagged", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        vim.cmd("edit " .. "abc")
+        same(icon .. "  1  2  3  4  5 ", Grapple.statusline())
+    end)
+end)
+
+describe("Statusline .format short", function()
+    before_each(function()
+        unload()
+        require("grapple").setup({ statusline = { builtin_formatter = "short" } })
+    end)
+    it("is correct without tags", function()
+        same("", require("grapple").statusline())
+    end)
+    it("is correct having 2 tags, current buffer is last", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar" }, Grapple)
+        same("2", Grapple.statusline())
+    end)
+    it("is correct having 5 tags, current buffer is 2", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        vim.cmd("edit " .. "bar")
+        same("2", Grapple.statusline())
+    end)
+    it("is correct having 5 tags, current buffer is not tagged", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        vim.cmd("edit " .. "abc")
+        same("", Grapple.statusline())
+    end)
+end)
+
+---@type grapple.formatter
+local function custom(opts_in, data)
+    local opts = { -- condensed line showing 4 slots and an optional extra slot
+        max_slots = 4,
+        inactive = "%s",
+        active = "[%s]",
+        empty_slot = "·", -- #slots > #tags, middledot
+        more_marks_indicator = "…", -- #slots < #tags, horizontal elipsis
+        more_marks_active_indicator = "[…]",
+    }
+    if data.scope_name == "git" then
+        data.scope_name = ""
+    end
+    local prefix = string.format("%s%s%s", opts_in.icon, data.scope_name == "" and "" or " ", data.scope_name)
+
+    -- build slots:
+    local status = {}
+    local max_tags = #data.tags
+    for i = 1, opts.max_slots do
+        local tag_fmt = opts.inactive
+        local tag_str = "" .. i
+        if i > max_tags then -- more slots then ...
+            tag_str = opts.empty_slot
+        else
+            local tag = data.tags[i]
+            if data.current and data.current.path == tag.path then
+                tag_fmt = opts.active
+            end
+        end
+        table.insert(status, string.format(tag_fmt, tag_str))
+    end
+    -- extra slot:
+    if max_tags > opts.max_slots then -- more marks then...
+        local ind = opts.more_marks_indicator
+        for i = opts.max_slots + 1, max_tags do
+            local tag = data.tags[i]
+            if data.current and data.current.path == tag.path then
+                ind = opts.more_marks_active_indicator
+                break
+            end
+        end
+        table.insert(status, ind)
+    end
+
+    return prefix .. " " .. table.concat(status)
+end
+
+describe("Statusline .format custom formatter", function()
+    before_each(function()
+        unload()
+        require("grapple").setup({
+            statusline = {
+                formatter = custom,
+            },
+        })
+    end)
+    it("is correct without tags", function()
+        same(icon .. " ····", require("grapple").statusline())
+    end)
+    it("is correct having 2 tags, current buffer is last", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar" }, Grapple)
+        same(icon .. " 1[2]··", Grapple.statusline())
+    end)
+    it("is correct having 5 tags, current buffer is 2", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        vim.cmd("edit " .. "bar")
+        same(icon .. " 1[2]34…", Grapple.statusline())
+    end)
+    it("is correct having 5 tags, current buffer is last", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        same(icon .. " 1234[…]", Grapple.statusline())
+    end)
+    it("is correct having 5 tags, current buffer is not tagged", function()
+        local Grapple = require("grapple")
+        add({ "foo", "bar", "baz", "xyz", "zyx" }, Grapple)
+        vim.cmd("edit " .. "abc")
+        same(icon .. " 1234…", Grapple.statusline())
     end)
 end)


### PR DESCRIPTION
This PR implements issue [feature: Statusline caching and custom functions #147](https://github.com/cbochs/grapple.nvim/issues/147) and adds the following:

1. Statusline caching.
2. A uniform hook for the user to implement a statusline, reusing
the caching and the data provided by `grapple`.
3. Builtin "update" support for various statusline plugins.

#### Changes

1. Added lua component `grapple.statusline` and corresponding tests.
2. Added properties to `grapple.settings.statusline`.
3. Api `Grapple.statusline`: Uses the new component. Does not return `nil` anymore.
4. The `lualine grapple` component: Changed to use the new version of `Grapple.statusline`.

The second `lualine` example in the docs uses two api methods which are not changed:

```lua
function Grapple.exists(opts)
function Grapple.name_or_index(opts)
```

The same can now be achieved by using:

```lua
Grapple.setup({ statusline = { builtin_formatter = "short" }})
```

#### Considerations

The statusline is opt-in and only activates when the user invokes `Grapple.statusline`. As such it is a top level component.

Optimize the number of steps in the code needed to produce a line after the initial setup. As a consequence, method `Grapple.statusline` has no `opts` argument that would need to be merged.

Ultimately, only 2 steps are needed:

- Get the statusline component: `require("grapple.statusline").get()`
- Display its cached line: `line:format()`

Works across statusline plugins in the same manner. Currently, the second example in the docs is `lualine` specific.

Autodetect the statusline plugin in use and provide an `on_event` callback. This considerably improves the responsiveness of `lualine`.

#### Suggestions

Nice to have perhaps: Extend the default formatter by adding empty_slots, more_marks and scope_name. See test case "custom formatter" and the `grappleline` plugin.

Remove the second `lualine` example from the docs, in favor of `builtin_formatter = "short"`.

#### Questions

##### Api

The new statusline component has a public api:

```lua
Statusline.formatters
function Statusline.get()
function Statusline:format()
function Statusline:is_current_buffer_tagged()
```

What's a good way to distinguish that api from all the other methods in the component?

##### Events

When using event `GrappleUpdate`, the dreaded `nested` error occurred:

```lua

function Statusline:subscribe_to_events()
    vim.api.nvim_create_autocmd({ "BufEnter" }, {
        group = STATUSLINE_GROUP,
        pattern = "*",
        callback = function()
            self:update()
        end,
    })
    vim.api.nvim_create_autocmd({ "User" }, { -- no scope name in event
        group = STATUSLINE_GROUP,
        pattern = "GrappleScopeChanged",
        callback = function()
            self:update()
        end,
    })
    vim.api.nvim_create_autocmd({ "User" }, -- crash
        group = STATUSLINE_GROUP,
        nested = false,
        pattern = "GrappleUpdate",
        callback = function()
            self:update()
        end,
    })
end
```

Perhaps it's better to not use the events provided by grapple. In my opinion, the `api decoration` is a good solution.

#### See also

Using mini.statusline in my config: [config-mini.statusline](https://github.com/abeldekat/nvim_pde/blob/7b432af1b21fead5e192068ab3a3c54249d1c0c9/lua/ak/config/ui/mini_statusline.lua#L145) [config-grapple](https://github.com/abeldekat/nvim_pde/blob/7b432af1b21fead5e192068ab3a3c54249d1c0c9/lua/ak/config/editor/grapple_pr.lua#L1) [deps-editor](https://github.com/abeldekat/nvim_pde/blob/7b432af1b21fead5e192068ab3a3c54249d1c0c9/lua/ak/deps/editor.lua#L41) [deps-ui](https://github.com/abeldekat/nvim_pde/blob/7b432af1b21fead5e192068ab3a3c54249d1c0c9/lua/ak/deps/ui.lua#L40)

#### Todo

Update the documentation.
