### PR TITLE
fix: problems with paths with spaces

### DIFF
--- a/lua/grapple/window.lua
+++ b/lua/grapple/window.lua
@@ -255,9 +255,10 @@ function Window:parse_lines()
 end
 
 ---@param line string
+---@param name string | nil
 ---@return integer min_col
-function Window:minimum_column(line)
-    return self.content:minimum_column(line)
+function Window:minimum_column(line, name)
+    return self.content:minimum_column(line, name)
 end
 
 ---@return string? error
@@ -405,7 +406,7 @@ function Window:create_buffer_defaults(buf_id)
         end
 
         local line = self:current_line()
-        local expected_column = self:minimum_column(line)
+        local expected_column = self:minimum_column(line, self:current_entry().data.name)
         local cursor = vim.api.nvim_win_get_cursor(self.win_id)
 
         if cursor[2] < expected_column then

--- a/tests/grapple/tag_content_spec.lua
+++ b/tests/grapple/tag_content_spec.lua
@@ -4,54 +4,67 @@ describe("TagContent", function()
     describe(".minimum_column", function()
         local test_cases = {
             -- No ID or invalid ID
-            { 0, "" },
-            { 0, "/some_path" },
-            { 0, "/001/some_path" },
-            { 0, "001" },
+            { 0, "", nil, false },
+            { 0, "/some_path", nil, false },
+            { 0, "/001/some_path", nil, false },
+            { 0, "001", nil, false },
 
             -- Partial ID
-            { 3, "/0 /some_path" },
-            { 4, "/00 /some_path" },
+            { 3, "/0 /some_path", nil, false },
+            { 4, "/00 /some_path", nil, false },
 
             -- ID only
-            { 5, "/000 /some_path" },
-            { 5, "/000 " },
-            { 5, "/000           " },
-            { 5, "/000           /some_path" },
+            { 5, "/000 /some_path", nil, false },
+            { 5, "/000 ", nil, false },
+            { 5, "/000           ", nil, false },
+            { 5, "/000           /some_path", nil, false },
 
             -- ID + name
-            { 9, "/001 bob /some_path" },
-            { 9, "/002 bob bob" },
-            { 9, "/003 bob      bob  " },
-            { 9, "/004 bob " },
-            { 7, "/005 a /some_path" },
-            { 7, "/006 a " },
-            { 7, "/007 a           " },
+            { 9, "/001 bob /some_path", "bob", false },
+            { 9, "/002 bob bob", "bob", false },
+            { 9, "/003 bob      bob  ", "bob", false },
+            { 9, "/004 bob ", "bob", false },
+            { 7, "/005 a /some_path", "a", false },
+            { 7, "/006 a ", "a", false },
+            { 7, "/007 a           ", "a", false },
 
             -- ID + icon
-            { 9, "/001  /some_path" },
-            { 9, "/002  /some_path" },
-            { 9, "/003  /some_path" },
-            { 9, "/004  " },
-            { 9, "/005            " },
+            { 9, "/001  /some_path", nil, true },
+            { 9, "/002  /some_path", nil, true },
+            { 9, "/003  /some_path", nil, true },
+            { 9, "/004  ", nil, true },
+            { 9, "/005            ", nil, true },
 
             -- ID + icon + name
-            { 13, "/001  bob /some_path" },
-            { 13, "/002  bob " },
-            { 11, "/003  c /some_path" },
-            { 11, "/004  c " },
-            { 11, "/005  c           " },
+            { 13, "/001  bob /some_path", "bob", true },
+            { 13, "/002  bob ", "bob", true },
+            { 11, "/003  c /some_path", "c", true },
+            { 11, "/004  c ", "c", true },
+            { 11, "/005  c           ", "c", true },
 
-            -- Assumed behaviour (last part editable)
-            { 16, "/000 /some_path /another_path" },
+            -- Paths and names with spaces
+            { 19, "/001  bob alice /some_path", "bob alice", true },
+            { 19, "/001  bob alice /some_path with_a_space", "bob alice", true },
+            { 13, "/001  bob /some_path with_a_space", "bob", true },
+            { 9, "/001 bob /some_path with_a_space", "bob", false },
         }
+
+        local App = require("grapple.app")
+        local app = App:get()
+        ---@diagnostic disable-next-line: inject-field
+        app.settings.name_pos = "start"
 
         for _, test_case in ipairs(test_cases) do
             local expected = test_case[1]
             local line = test_case[2]
+            local name = test_case[3]
+            local icons = test_case[4]
+
+            ---@diagnostic disable-next-line: inject-field
+            app.settings.icons = icons
 
             it(string.format('expected col %d, line "%s"', expected, line), function()
-                assert.same(expected, TagContent:new(nil, nil, nil, nil):minimum_column(line))
+                assert.same(expected, TagContent:new(nil, nil, nil, nil):minimum_column(line, name))
             end)
         end
     end)


### PR DESCRIPTION
Earlier today, I encountered a problem when adding files with spaces in their name. Closing and reopening Neovim or even just opening the Tags Window would lose part of the file name and I could no longer open the correct file via Grapple.

Example: "this is a file.md" would become "file.md", everything up to the part after the last whitespace was dropped.

I figured this would be reasonably simple to fix and looked into it myself. My code is probably pretty bad, but it seems to work, and I included some comments and new tests.