### PR TITLE
feat: use relative path for a better initial view in `:buffers`

### DIFF
--- a/lua/grapple/tag.lua
+++ b/lua/grapple/tag.lua
@@ -25,7 +25,9 @@ function Tag:select(command)
     local app = require("grapple").app()
 
     command = command or app.settings.command
-    command(self.path)
+    -- Use relative path for a better initial view in `:buffers`
+    local path_norm = vim.fn.fnameescape(vim.fn.fnamemodify(self.path, ":."))
+    command(path_norm)
 
     if self.cursor then
         local current_cursor = vim.api.nvim_win_get_cursor(0)


### PR DESCRIPTION
Use relative paths for a better initial view in :buffers and ensure that the result of `bufname()` is also a relative path.

before:
<img width="326" alt="Snipaste_2024-05-23_10-11-17" src="https://github.com/cbochs/grapple.nvim/assets/46311996/77ffd19a-53b0-48a8-bd59-8fbad65613a6">
<img width="404" alt="Snipaste_2024-05-23_10-11-06" src="https://github.com/cbochs/grapple.nvim/assets/46311996/7120f4ec-2117-4411-959d-b7e61be1333e">

after:
<img width="300" alt="Snipaste_2024-05-23_10-10-23" src="https://github.com/cbochs/grapple.nvim/assets/46311996/b6c849ab-ab51-4496-8a32-cc8c41b3cc31">
<img width="271" alt="Snipaste_2024-05-23_10-10-43" src="https://github.com/cbochs/grapple.nvim/assets/46311996/c9c5ad5e-76e5-4447-bf1e-26808abb2b02">

