### PR TITLE
fix(docs): rename highlight group for window background

### DIFF
--- a/doc/grapple.txt
+++ b/doc/grapple.txt
@@ -942,7 +942,7 @@ WINDOW HIGHLIGHTS ~
   GrappleCurrent   SpecialChar       gui=bold   All windows for current
                                                 status
 
-  GrappleFloat     NormalFloat       N/A        All windows for background
+  GrappleNormal    NormalFloat       N/A        All windows for background
 
   GrappleBorder    FloatBorder       N/A        All windows for border
 


### PR DESCRIPTION
`GrappleFloat` hl group is named incorrectly in the documentation, it should be `GrappleNormal`.