### PR TITLE
fix: use get_clients or fall back to get_active_clients

### DIFF
--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -152,8 +152,7 @@ local DEFAULT_SETTINGS = {
                 debounce = 250, -- ms
             },
             resolver = function()
-                -- TODO: Don't use vim.lsp.get_clients, it's a nvim-0.10 feature
-                local clients = vim.lsp.get_active_clients({ bufnr = 0 })
+                local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)({ bufnr = 0 })
                 if #clients == 0 then
                     return
                 end


### PR DESCRIPTION
`get_active_clients` was deprecated in nvim v0.11 nightly and removed in v0.12. This small change uses `get_clients` if available and falls back to `get_active_clients` if not