### PR TITLE
fix: remove deprecated vim.validate table usage

### DIFF
--- a/lua/grapple/scope_manager.lua
+++ b/lua/grapple/scope_manager.lua
@@ -71,10 +71,8 @@ end
 ---@param definition grapple.scope_definition
 ---@return string? error
 function ScopeManager:define(definition)
-    vim.validate({
-        name = { definition.name, "string" },
-        resolver = { definition.resolver, "function" },
-    })
+    Util.validate("name", definition.name, "string")
+    Util.validate("resolver", definition.resolver, "function")
 
     if self:exists(definition.name) then
         if not definition.force then

--- a/lua/grapple/tag_container.lua
+++ b/lua/grapple/tag_container.lua
@@ -1,5 +1,6 @@
 local Path = require("grapple.path")
 local Tag = require("grapple.tag")
+local Util = require("grapple.util")
 
 ---@class grapple.tag_container
 ---@field id string
@@ -31,7 +32,7 @@ end
 ---@param opts grapple.options
 ---@return string? error
 function TagContainer:insert(opts)
-    vim.validate({ path = { opts.path, "string" } })
+    Util.validate("path", opts.path, "string")
 
     if opts.index and (opts.index < 1 or opts.index > #self.tags + 1) then
         return string.format("tag insert opts.index is out-of-bounds: %s", opts.index)

--- a/lua/grapple/tag_manager.lua
+++ b/lua/grapple/tag_manager.lua
@@ -1,4 +1,5 @@
 local TagContainer = require("grapple.tag_container")
+local Util = require("grapple.util")
 
 ---@class grapple.tag_manager
 ---@field state grapple.state
@@ -95,9 +96,7 @@ end
 ---@param time_limit integer | string
 ---@return string[] | nil pruned, string? error
 function TagManager:prune(time_limit)
-    vim.validate({
-        time_limit = { time_limit, { "number", "string" } },
-    })
+    Util.validate("time_limit", time_limit, { "number", "string" })
 
     local limit_sec
     if type(time_limit) == "number" then

--- a/lua/grapple/util.lua
+++ b/lua/grapple/util.lua
@@ -1,5 +1,32 @@
 local Util = {}
 
+local has_validate_positional = vim.fn.has("nvim-0.11") == 1
+
+---Compatibility wrapper for vim.validate across Neovim 0.10 and 0.11+
+---@param name string
+---@param value any
+---@param validator string | string[] | fun(val: any): boolean, string?
+---@param optional? boolean | string
+---@param message? string
+function Util.validate(name, value, validator, optional, message)
+    if has_validate_positional then
+        return vim.validate(name, value, validator, optional, message)
+    end
+
+    local spec = { [name] = { value, validator } }
+
+    if message ~= nil then
+        if optional ~= nil then
+            table.insert(spec[name], optional)
+        end
+        table.insert(spec[name], message)
+    elseif optional ~= nil then
+        table.insert(spec[name], optional)
+    end
+
+    return vim.validate(spec)
+end
+
 ---Escapes a string so it can be used as a string pattern
 ---@param str string
 ---@return string escaped string


### PR DESCRIPTION
Closes #197

## Summary
- fix Neovim 0.12 deprecation warnings from `vim.validate({ ... })`
- preserve support for Neovim >= 0.10 with a small compatibility helper
- no behavior changes intended

## Testing
Tested locally on:
- NVIM v0.10.4
- NVIM v0.11.4
- NVIM v0.12.0

Verified:
- Grapple startup succeeds
- test suite passes
- `:checkhealth vim.deprecated` is clean on Neovim 0.12