### PR TITLE
feat: add dynamic_win_width option for tags window

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ require("grapple").setup({
     ---@type fun(): string?
     loaded_title = nil,
 
+    ---Enable dynamic tags window width (see [Dynamic Window Width](#dynamic-window-width))
+    ---Set to a float in (0, 1) to enable; false uses the static win_opts.width
+    ---@type number | false
+    dynamic_win_width = false,
+
     ---Additional window options for Grapple windows
     ---See :h nvim_open_win
     ---@type grapple.vim.win_opts
@@ -860,6 +865,56 @@ require("grapple").open_tags()
 -- Open the tags window for a different scope
 require("grapple").open_tags("global")
 ```
+
+</details>
+
+### Dynamic Window Width
+
+By default the tags window opens at a fixed width (`win_opts.width`). Setting
+`dynamic_win_width` to a float between 0 and 1 (exclusive) enables automatic
+width calculation every time the tags window is opened.
+
+**How the width is calculated:**
+
+1. Each tag's visible line length is estimated from its rendered path (honouring
+   the active `style`) plus its name length if one is set.
+2. A fixed overhead is added for line chrome: `10` columns with icons enabled,
+   `7` without (`/001` + icon + separators + padding).
+3. The final width is clamped between `win_opts.width` (minimum) and
+   `columns * dynamic_win_width` (maximum), where `columns` is the current
+   editor width.
+
+`win_opts.width` therefore serves a dual role: the exact static width when
+`dynamic_win_width = false`, and the minimum floor when it is enabled.
+
+<details>
+<summary><b>Example</b></summary>
+
+```lua
+require("grapple").setup({
+    -- Enable dynamic width, capped at 90% of the editor width.
+    dynamic_win_width = 0.9,
+
+    win_opts = {
+        -- Minimum width when dynamic_win_width is set;
+        -- exact width when dynamic_win_width = false.
+        width = 40,
+        height = 12,
+        border = "rounded",
+    },
+})
+```
+
+With a 200-column editor and a longest tag line of 70 characters (path + name)
+and icons enabled:
+
+```
+raw_width   = 70 + 10 (overhead) = 80
+max_allowed = floor(200 * 0.9)   = 180
+final_width = clamp(80, 40, 180) = 80
+```
+
+When the scope has no tags yet the window opens at `win_opts.width` (40 above).
 
 </details>
 

--- a/doc/grapple.txt
+++ b/doc/grapple.txt
@@ -16,6 +16,7 @@ Table of Contents                                  *grapple-table-of-contents*
   - Tags                                           |grapple-grapple.nvim-tags|
   - Scopes                                       |grapple-grapple.nvim-scopes|
   - Grapple Windows                     |grapple-grapple.nvim-grapple-windows|
+  - Dynamic Window Width                           |grapple-dynamic-win-width|
   - Persistent State                   |grapple-grapple.nvim-persistent-state|
   - Integrations                           |grapple-grapple.nvim-integrations|
 
@@ -272,6 +273,11 @@ Default Settings ~
         ---@type fun(): string?
         loaded_title = nil,
     
+        ---Enable dynamic tags window width (see |grapple-dynamic-win-width|)
+        ---Set to a float in (0, 1) to enable; false to use a static width
+        ---@type number | false
+        dynamic_win_width = false,
+
         ---Additional window options for Grapple windows
         ---See :h nvim_open_win
         ---@type grapple.vim.win_opts
@@ -861,6 +867,73 @@ Examples ~
     -- Open the tags window for a different scope
     require("grapple").open_tags("global")
 <
+
+
+DYNAMIC WINDOW WIDTH ~
+                                              *grapple-dynamic-win-width*
+
+By default, the tags window opens at a fixed width set by `win_opts.width`.
+This can produce a window that is either too narrow (wrapping long paths into
+multiple lines) or unnecessarily wide (wasting screen space when tags have
+short paths).
+
+Setting `dynamic_win_width` to a float between 0 and 1 (exclusive) enables
+automatic width calculation every time the tags window is opened. The value is
+the maximum allowed window width expressed as a fraction of the editor width.
+`win_opts.width` is reinterpreted as the minimum: the window will never be
+narrower than that value, regardless of how short the tag paths are.
+
+Width calculation ~
+
+For each tag in the current scope the visible line width is estimated:
+
+1. The rendered path is computed according to the active `style`:
+   - `"relative"`: the scope root prefix is stripped, leaving only the
+     path relative to the git/project root.
+   - `"basename"`: only the filename (no directory) is used.
+
+2. If the tag has a name set (via `R` in the tags window), its length plus 2
+   characters (for the space Neovim inserts before EOL virtual text and icon
+   padding) is added to the path length.
+
+3. A fixed overhead is added for the rendered line chrome:
+   - With icons enabled: 10 columns (`/001` + space + icon + space + 2
+     padding columns).
+   - With icons disabled: 7 columns (`/001` + space + 2 padding columns).
+
+4. The final width is:
+   `clamp(max_path_len + overhead, win_opts.width, columns * dynamic_win_width)`
+
+   Where `columns` is the current editor width (`vim.o.columns`).
+
+Example ~
+
+>lua
+    require("grapple").setup({
+        -- Enable dynamic width, capped at 90% of the editor width.
+        dynamic_win_width = 0.9,
+
+        win_opts = {
+            -- Minimum width: used as the floor when dynamic_win_width is set,
+            -- and as the exact static width when dynamic_win_width is false.
+            width = 40,
+            height = 12,
+            border = "rounded",
+        },
+    })
+<
+
+With a 200-column editor and tags whose longest relative path is 60 characters
+and whose name is 8 characters:
+
+  max_path_len = 60 + 8 + 2 (name overhead) = 70
+  overhead     = 10 (icons enabled)
+  raw_width    = 70 + 10 = 80
+  max_allowed  = floor(200 * 0.9) = 180
+  final_width  = clamp(80, 40, 180) = 80
+
+If the scope has no tags yet, `max_path_len` is 0 and the window opens at
+the minimum width (40 in the example above).
 
 
 SCOPES WINDOW ~

--- a/lua/grapple/app.lua
+++ b/lua/grapple/app.lua
@@ -482,9 +482,10 @@ end
 
 ---Convenience function to open content in a new floating window
 ---@param content grapple.tag_content | grapple.scope_content | grapple.container_content
+---@param win_opts? grapple.vim.win_opts
 ---@return string? error
-function App:open_window(content)
-    local window = Window:new(self.settings.win_opts)
+function App:open_window(content, win_opts)
+    local window = Window:new(win_opts or self.settings.win_opts)
 
     window:open()
     window:attach(content)
@@ -513,7 +514,35 @@ function App:open_tags(opts)
         self.settings.styles[opts.style or self.settings.style]
     )
 
-    return self:open_window(content)
+    local win_opts = self.settings.win_opts
+    local fraction = self.settings.dynamic_win_width
+    if type(fraction) == "number" and fraction > 0 and fraction < 1 then
+        local container, _ = self.tag_manager:load(scope.id)
+        if container then
+            local scope_path = scope.path
+            local style = opts.style or self.settings.style
+            local max_len = 0
+            for _, tag in ipairs(container.tags) do
+                local display = tag.path or ""
+                if style == "relative" and display:sub(1, #scope_path + 1) == scope_path .. "/" then
+                    display = display:sub(#scope_path + 2)
+                elseif style == "basename" then
+                    display = vim.fn.fnamemodify(display, ":t")
+                end
+                local w = #display
+                if w > max_len then
+                    max_len = w
+                end
+            end
+            -- Overhead: "/001" (4) + icon (2) + separators (2) = 8; add 2 for padding.
+            local overhead = self.settings.icons and 10 or 7
+            local max_w = math.floor(vim.o.columns * fraction)
+            local width = math.max(win_opts.width, math.min(max_w, max_len + overhead))
+            win_opts = vim.tbl_extend("force", win_opts, { width = width })
+        end
+    end
+
+    return self:open_window(content, win_opts)
 end
 
 ---Open a floating window populated with all defined scopes

--- a/lua/grapple/app.lua
+++ b/lua/grapple/app.lua
@@ -529,7 +529,10 @@ function App:open_tags(opts)
                 elseif style == "basename" then
                     display = vim.fn.fnamemodify(display, ":t")
                 end
-                local w = #display
+                -- +2 for the space Neovim inserts before eol virt_text and
+                -- one extra for any icon padding when name_pos = "start".
+                local name_extra = tag.name and (#tag.name + 2) or 0
+                local w = #display + name_extra
                 if w > max_len then
                     max_len = w
                 end

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -409,6 +409,13 @@ local DEFAULT_SETTINGS = {
         end,
     },
 
+    ---When set to a number between 0 and 1 (exclusive), the tags window width
+    ---is calculated dynamically to fit the longest tag path. The value specifies
+    ---the maximum window width as a fraction of the editor width. win_opts.width
+    ---is used as the minimum width. Set to false to use a static width.
+    ---@type number | false
+    dynamic_win_width = false,
+
     ---Additional window options for Grapple windows
     ---See :h nvim_open_win
     ---@type grapple.vim.win_opts


### PR DESCRIPTION
## Summary

Add a `dynamic_win_width` setting that automatically sizes the tags window to fit the longest tag
path rather than using a fixed width.

**How it works:**

- Accepts a `number` between 0 and 1 (exclusive) representing the maximum width as a fraction of
  the editor width, or `false` (default) to keep the existing static-width behavior.
- `win_opts.width` is repurposed as the minimum floor: the computed width is clamped between
  `win_opts.width` and `vim.o.columns * dynamic_win_width`.
- Width calculation accounts for: display style (`relative` strips the scope path prefix,
  `basename` uses only the filename), optional tag names rendered as EOL virtual text, icon
  padding, and the index/separator overhead (`/001 ` + icon = ~10 cols with icons, ~7 without).
- `open_window(content, win_opts?)` gains an optional second parameter so computed opts are passed
  per-call without mutating global settings.

**No breaking changes.** Default is `false`; existing configs behave identically.

```lua
-- Example
require("grapple").setup({
    dynamic_win_width = 0.8,  -- max 80% of editor width
    win_opts = {
        width = 40,           -- minimum width (floor)
    },
})
```
