### PR TITLE
feat: add name_on_tag, suggest_name, and confirm_untag prompts to toggle()

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,16 @@ require("grapple").setup({
     ---@type string | boolean
     quick_select = "123456789",
 
+    ---Prompt for an optional name when creating a tag via toggle()
+    ---Empty input creates an unnamed tag; Esc cancels the operation
+    ---@type boolean
+    name_on_tag = false,
+
+    ---Require confirmation before removing a tag via toggle()
+    ---Default choice is No, so a plain <CR> is safe
+    ---@type boolean
+    confirm_untag = false,
+
     ---Default command to use when selecting a tag
     ---@type fun(path: string)
     command = vim.cmd.edit,
@@ -385,7 +395,10 @@ require("grapple").untag({ scope = "global" })
 
 #### `Grapple.toggle`
 
-Toggle a Grapple tag.
+Toggle a Grapple tag. When [`name_on_tag`](#toggle-prompts) is enabled, a
+name prompt appears before creating a new tag. When
+[`confirm_untag`](#toggle-prompts) is enabled, a confirmation dialog appears
+before removing an existing tag.
 
 **API**: `require("grapple").toggle(opts)`
 
@@ -395,7 +408,14 @@ Toggle a Grapple tag.
 <summary><b>Examples</b></summary>
 
 ```lua
--- Toggle a tag on the current buffer
+-- Toggle a tag on the current buffer (silent, default behaviour)
+require("grapple").toggle()
+
+-- Toggle with interactive prompts enabled in setup()
+require("grapple").setup({
+    name_on_tag = true,   -- prompt for a name when tagging
+    confirm_untag = true, -- confirm before untagging
+})
 require("grapple").toggle()
 ```
 
@@ -817,6 +837,49 @@ require("grapple").setup({
 ```
 
 </details>
+
+## Toggle Prompts
+
+Two optional settings add interactive prompts to the `toggle()` command.
+Both are `false` by default to preserve the current silent behaviour.
+
+### `name_on_tag`
+
+When `name_on_tag = true`, calling `toggle()` on an untagged buffer opens a
+`vim.ui.input` prompt before creating the tag:
+
+- Type a name and press `<CR>` to create a **named** tag.
+- Press `<CR>` on an empty input to create an **unnamed** tag (same as the
+  default behaviour).
+- Press `<Esc>` (or cancel) to abort without creating a tag.
+
+The prompt respects any `vim.ui.input` override active in your configuration
+(e.g. a floating-window input from snacks.nvim or dressing.nvim).
+
+### `confirm_untag`
+
+When `confirm_untag = true`, calling `toggle()` on an already-tagged buffer
+shows a yes/no confirmation dialog before removing the tag. The default choice
+is **No**, so an accidental `<CR>` is safe.
+
+<details>
+<summary><b>Example</b></summary>
+
+```lua
+require("grapple").setup({
+    -- Prompt for a name each time a new tag is created via toggle().
+    name_on_tag = true,
+
+    -- Ask before removing a tag via toggle().
+    confirm_untag = true,
+})
+```
+
+</details>
+
+> [!NOTE]
+> Both settings only affect `toggle()`. Direct calls to `tag()` and `untag()`
+> are always silent and require no confirmation.
 
 ## Grapple Windows
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ require("grapple").setup({
     ---@type boolean
     confirm_untag = false,
 
+    ---Pre-fill the name prompt with the file basename (no extension) when
+    ---name_on_tag is true. Hidden files keep their full name.
+    ---e.g. "my_file.txt" -> "my_file", ".config" -> ".config"
+    ---@type boolean
+    suggest_name = false,
+
     ---Default command to use when selecting a tag
     ---@type fun(path: string)
     command = vim.cmd.edit,
@@ -840,8 +846,8 @@ require("grapple").setup({
 
 ## Toggle Prompts
 
-Two optional settings add interactive prompts to the `toggle()` command.
-Both are `false` by default to preserve the current silent behaviour.
+Three optional settings add interactive prompts to the `toggle()` command.
+All are `false` by default to preserve the current silent behaviour.
 
 ### `name_on_tag`
 
@@ -856,6 +862,17 @@ When `name_on_tag = true`, calling `toggle()` on an untagged buffer opens a
 The prompt respects any `vim.ui.input` override active in your configuration
 (e.g. a floating-window input from snacks.nvim or dressing.nvim).
 
+### `suggest_name`
+
+When `suggest_name = true` (and `name_on_tag` is also `true`), the name
+prompt is pre-filled with a suggestion derived from the current file:
+
+- Regular files: basename without extension — `my_file.txt` → `my_file`
+- Hidden files: full basename — `.config` → `.config`
+
+The suggestion is editable; clearing it and pressing `<CR>` still creates an
+unnamed tag. Has no effect when `name_on_tag` is `false`.
+
 ### `confirm_untag`
 
 When `confirm_untag = true`, calling `toggle()` on an already-tagged buffer
@@ -867,8 +884,9 @@ is **No**, so an accidental `<CR>` is safe.
 
 ```lua
 require("grapple").setup({
-    -- Prompt for a name each time a new tag is created via toggle().
+    -- Prompt for a name when tagging, pre-filled with the file stem.
     name_on_tag = true,
+    suggest_name = true,
 
     -- Ask before removing a tag via toggle().
     confirm_untag = true,
@@ -878,8 +896,8 @@ require("grapple").setup({
 </details>
 
 > [!NOTE]
-> Both settings only affect `toggle()`. Direct calls to `tag()` and `untag()`
-> are always silent and require no confirmation.
+> All three settings only affect `toggle()`. Direct calls to `tag()` and
+> `untag()` are always silent and require no confirmation.
 
 ## Grapple Windows
 

--- a/doc/grapple.txt
+++ b/doc/grapple.txt
@@ -15,6 +15,7 @@ Table of Contents                                  *grapple-table-of-contents*
   - Usage                                         |grapple-grapple.nvim-usage|
   - Tags                                           |grapple-grapple.nvim-tags|
   - Scopes                                       |grapple-grapple.nvim-scopes|
+  - Toggle Prompts                                    |grapple-toggle-prompts|
   - Grapple Windows                     |grapple-grapple.nvim-grapple-windows|
   - Persistent State                   |grapple-grapple.nvim-persistent-state|
   - Integrations                           |grapple-grapple.nvim-integrations|
@@ -245,7 +246,17 @@ Default Settings ~
         ---An empty string or false will disable quick select
         ---@type string | boolean
         quick_select = "123456789",
-    
+
+        ---Prompt for an optional name when creating a tag via toggle()
+        ---See |grapple-toggle-prompts|
+        ---@type boolean
+        name_on_tag = false,
+
+        ---Require confirmation before removing a tag via toggle()
+        ---See |grapple-toggle-prompts|
+        ---@type boolean
+        confirm_untag = false,
+
         ---Default command to use when selecting a tag
         ---@type fun(path: string)
         command = vim.cmd.edit,
@@ -810,6 +821,48 @@ Examples ~
         default_scopes = {
             lsp = false
         }
+    })
+<
+
+
+TOGGLE PROMPTS                                        *grapple-toggle-prompts*
+
+Two optional settings add interactive prompts to the |grapple-toggle| command.
+Both are `false` by default to preserve the current silent behaviour.
+
+name_on_tag ~
+
+When `name_on_tag = true`, calling `toggle()` on an untagged buffer opens a
+`vim.ui.input` prompt before creating the tag:
+
+- Type a name and press `<CR>` to create a named tag.
+- Press `<CR>` on an empty input to create an unnamed tag (same as the default
+  behaviour).
+- Press `<Esc>` (or cancel the input) to abort without creating a tag.
+
+The prompt respects any `vim.ui.input` override active in your configuration
+(e.g. a floating-window input provided by snacks.nvim or dressing.nvim).
+
+confirm_untag ~
+
+When `confirm_untag = true`, calling `toggle()` on an already-tagged buffer
+shows a confirmation dialog before removing the tag:
+
+- The default choice is **No**, so an accidental `<CR>` is safe.
+- Choosing **Yes** removes the tag immediately.
+
+Both settings only affect `toggle()`. Direct calls to `tag()` and `untag()`
+are always silent and require no confirmation.
+
+Example ~
+
+>lua
+    require("grapple").setup({
+        -- Prompt for a name each time a new tag is created via toggle().
+        name_on_tag = true,
+
+        -- Ask before removing a tag via toggle().
+        confirm_untag = true,
     })
 <
 

--- a/lua/grapple/app.lua
+++ b/lua/grapple/app.lua
@@ -161,6 +161,9 @@ end
 
 ---Toggle a tag on a path, URI, or buffer. Lookup is done by index, name, path, or buffer
 ---By default, uses the current scope
+---When settings.confirm_untag is true, a confirmation dialog is shown before
+---removing an existing tag. When settings.name_on_tag is true, vim.ui.input is
+---shown to supply an optional name when creating a new tag.
 ---@param opts? grapple.options
 ---@return string? error
 function App:toggle(opts)
@@ -172,13 +175,49 @@ function App:toggle(opts)
     end
     opts.path = path
 
-    return self:enter_with_save(function(container)
-        if container:has(opts) then
-            return container:remove(opts)
-        else
-            return container:insert(opts)
-        end
+    -- Fast path: no interactive prompts configured.
+    if not self.settings.name_on_tag and not self.settings.confirm_untag then
+        return self:enter_with_save(function(container)
+            if container:has(opts) then
+                return container:remove(opts)
+            else
+                return container:insert(opts)
+            end
+        end, { scope = opts.scope, scope_id = opts.scope_id })
+    end
+
+    -- Check whether the tag already exists so we can branch on it.
+    local tagged, _ = self:enter_with_result(function(container)
+        return container:has(opts), nil
     end, { scope = opts.scope, scope_id = opts.scope_id })
+
+    if tagged then
+        if self.settings.confirm_untag then
+            local choice = vim.fn.confirm("Remove grapple tag?", "&Yes\n&No", 2)
+            if choice ~= 1 then
+                return
+            end
+        end
+        return self:enter_with_save(function(container)
+            return container:remove(opts)
+        end, { scope = opts.scope, scope_id = opts.scope_id })
+    else
+        if self.settings.name_on_tag then
+            vim.ui.input({ prompt = "Tag name (optional): " }, function(name)
+                if name == nil then
+                    return
+                end
+                opts.name = name ~= "" and name or nil
+                self:enter_with_save(function(container)
+                    return container:insert(opts)
+                end, { scope = opts.scope, scope_id = opts.scope_id })
+            end)
+        else
+            return self:enter_with_save(function(container)
+                return container:insert(opts)
+            end, { scope = opts.scope, scope_id = opts.scope_id })
+        end
+    end
 end
 
 ---Select a tag by index, name, path, or buffer

--- a/lua/grapple/app.lua
+++ b/lua/grapple/app.lua
@@ -203,7 +203,13 @@ function App:toggle(opts)
         end, { scope = opts.scope, scope_id = opts.scope_id })
     else
         if self.settings.name_on_tag then
-            vim.ui.input({ prompt = "Tag name (optional): " }, function(name)
+            local default = nil
+            if self.settings.suggest_name and opts.path then
+                local basename = vim.fn.fnamemodify(opts.path, ":t")
+                -- Hidden files (e.g. ".config") keep their full name; others lose the extension
+                default = basename:sub(1, 1) == "." and basename or vim.fn.fnamemodify(opts.path, ":t:r")
+            end
+            vim.ui.input({ prompt = "Tag name (optional): ", default = default }, function(name)
                 if name == nil then
                     return
                 end

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -57,6 +57,14 @@ local DEFAULT_SETTINGS = {
     ---@type boolean
     confirm_untag = false,
 
+    ---When true and name_on_tag is also true, the vim.ui.input prompt is
+    ---pre-filled with the basename of the current file (without extension).
+    ---Hidden files (e.g. ".config") keep their full name. The user can edit
+    ---or clear the suggestion before confirming. Has no effect when
+    ---name_on_tag is false.
+    ---@type boolean
+    suggest_name = false,
+
     ---Default command to use when selecting a tag
     ---@type fun(path: string)
     command = vim.cmd.edit,

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -44,6 +44,19 @@ local DEFAULT_SETTINGS = {
     ---@type string | boolean
     quick_select = "123456789",
 
+    ---When true, toggle() prompts for an optional tag name via vim.ui.input
+    ---before creating the tag. An empty input creates an unnamed tag; pressing
+    ---Esc cancels the operation. When false, tags are created silently with no
+    ---name (current default behaviour).
+    ---@type boolean
+    name_on_tag = false,
+
+    ---When true, toggle() asks for confirmation before removing an existing tag.
+    ---The default choice is No, so a plain <CR> is safe. When false, tags are
+    ---removed immediately with no prompt (current default behaviour).
+    ---@type boolean
+    confirm_untag = false,
+
     ---Default command to use when selecting a tag
     ---@type fun(path: string)
     command = vim.cmd.edit,


### PR DESCRIPTION
## Summary

Add three opt-in boolean settings that make `toggle()` interactive: prompt for a tag
name on creation (optionally pre-filled), and ask for confirmation before removal.

**New settings:**

- `name_on_tag` (boolean, default `false`): when `true`, `toggle()` shows a
  `vim.ui.input` prompt ("Tag name (optional):") before creating a tag. Empty
  input -> unnamed tag; `<Esc>` cancels without tagging.
- `suggest_name` (boolean, default `false`): when `true` (and `name_on_tag` is
  also `true`), the name prompt is pre-filled with the file stem of the current
  buffer. Regular files lose their extension (`my_file.txt` -> `my_file`);
  hidden files keep their full name (`.config` -> `.config`). The suggestion is
  editable. Has no effect when `name_on_tag` is `false`.
- `confirm_untag` (boolean, default `false`): when `true`, `toggle()` shows a
  `vim.fn.confirm` dialog before removing an existing tag. The default choice is
  **No**, so an accidental `<CR>` is safe.

**Implementation notes:**

- Fast path: when all three settings are `false`, the original single
  `enter_with_save` code path is taken with zero overhead.
- `vim.ui.input` is async (callback-based), so tag existence is checked first
  with `enter_with_result`, then the save is performed inside the appropriate
  sync or async branch.
- Only `toggle()` is affected. `tag()` and `untag()` are unchanged.

**No breaking changes.** All settings default to `false`; existing behavior is
preserved exactly.

```lua
-- Example
require("grapple").setup({
    name_on_tag   = true,  -- prompt for a name when tagging
    suggest_name  = true,  -- pre-fill with file stem (e.g. "my_file")
    confirm_untag = true,  -- confirm before untagging
})