### PR TITLE
feat: add snacks.nvim and fzf-lua fuzzy picker integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ require("grapple").setup({
     ---@type integer | string
     prune = "30d",
 
+    ---Fuzzy picker opened by <C-f> inside the Grapple tags window.
+    ---"auto" tries snacks -> fzf-lua -> telescope in order of availability.
+    ---Set to false to disable the <C-f> keymap.
+    ---@type "snacks" | "fzf_lua" | "telescope" | "auto" | false
+    fuzzy_picker = "auto",
+
     ---User-defined tags title function for Grapple windows
     ---By default, uses the resolved scope's ID
     ---@type fun(scope: grapple.resolved_scope): string?
@@ -837,6 +843,7 @@ Open a floating window with all the tags for a given scope. This buffer is modif
 - **Renaming** (`R`): rename the tag under the cursor
 - **Quickfix** (`<c-q>`): send all tags to the quickfix list ([`:h quickfix`](https://neovim.io/doc/user/quickfix.html))
 - **Go up** (`-`): navigate up to the [scopes window](#scopes-window)
+- **Fuzzy picker** (`<c-f>`): hand off to the configured fuzzy picker (see [`fuzzy_picker`](#settings))
 - **Help** (`?`): open the help window
 
 **API**:
@@ -947,6 +954,54 @@ Grapple saves all scopes to a common directory. The default directory is named `
 
 ## Integrations
 
+### snacks.nvim
+
+You can use [snacks.nvim](https://github.com/folke/snacks.nvim) as a fuzzy picker for your tagged files.
+
+Open the picker directly with the Lua API:
+
+```lua
+require("grapple").open_snacks()
+-- or for a specific scope:
+require("grapple").open_snacks({ scope = "global" })
+```
+
+Or use the `:Grapple` command:
+
+```vim
+:Grapple open_snacks
+```
+
+Inside the picker:
+
+- `<cr>`: select the tag
+- `<C-x>`: delete the tag under the cursor
+- `<C-r>`: rename the tag under the cursor
+
+### fzf-lua
+
+You can use [fzf-lua](https://github.com/ibhagwan/fzf-lua) as a fuzzy picker for your tagged files.
+
+Open the picker directly with the Lua API:
+
+```lua
+require("grapple").open_fzf()
+-- or for a specific scope:
+require("grapple").open_fzf({ scope = "global" })
+```
+
+Or use the `:Grapple` command:
+
+```vim
+:Grapple open_fzf
+```
+
+Inside the picker:
+
+- `<cr>`: select the tag
+- `<C-x>`: delete the selected tag(s) (multi-select with `<Tab>`)
+- `<C-r>`: rename the tag under the cursor
+
 ### Telescope
 
 You can use [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) to search through your tagged files instead of the built in popup windows.
@@ -962,6 +1017,11 @@ Then use this command to see the grapple tags for the project in a telescope win
 ```vim
 :Telescope grapple tags
 ```
+
+Inside the picker:
+
+- `<cr>`: select the tag
+- `<C-X>`: delete the tag under the cursor
 
 ### Statusline
 

--- a/doc/grapple.txt
+++ b/doc/grapple.txt
@@ -18,6 +18,7 @@ Table of Contents                                  *grapple-table-of-contents*
   - Grapple Windows                     |grapple-grapple.nvim-grapple-windows|
   - Persistent State                   |grapple-grapple.nvim-persistent-state|
   - Integrations                           |grapple-grapple.nvim-integrations|
+  - Fuzzy Pickers                                      |grapple-fuzzy-pickers|
 
 ==============================================================================
 1. Grapple.nvim                                         *grapple-grapple.nvim*
@@ -256,6 +257,12 @@ Default Settings ~
         ---(e.g. "30d" or "2h" or "15m")
         ---@type integer | string
         prune = "30d",
+    
+        ---Fuzzy picker opened by <C-f> inside the Grapple tags window.
+        ---"auto" tries snacks -> fzf-lua -> telescope in order of availability.
+        ---Set to false to disable the <C-f> keymap.
+        ---@type "snacks" | "fzf_lua" | "telescope" | "auto" | false
+        fuzzy_picker = "auto",
     
         ---User-defined tags title function for Grapple windows
         ---By default, uses the resolved scope's ID
@@ -839,6 +846,7 @@ modifiable. Several actions are available by default:
 - **Renaming** (`R`): rename the tag under the cursor
 - **Quickfix** (`<c-q>`): send all tags to the quickfix list (||quickfix||)
 - **Go up** (`-`): navigate up to the |grapple-scopes-window|
+- **Fuzzy picker** (`<c-f>`): open the configured fuzzy picker (see |grapple-fuzzy-pickers|)
 - **Help** (`?`): open the help window
 
 **API**
@@ -961,6 +969,55 @@ loaded on startup and will are instead loaded on demand.
 
 INTEGRATIONS                               *grapple-grapple.nvim-integrations*
 
+                                                     *grapple-fuzzy-pickers*
+
+SNACKS.NVIM ~
+
+You can use snacks.nvim <https://github.com/folke/snacks.nvim> as a fuzzy
+picker for your tagged files.
+
+>lua
+    require("grapple").open_snacks()
+    -- or for a specific scope:
+    require("grapple").open_snacks({ scope = "global" })
+<
+
+Or via the Grapple command:
+
+>vim
+    :Grapple open_snacks
+<
+
+Inside the picker:
+
+- `<cr>`: select the tag
+- `<C-x>`: delete the tag under the cursor
+- `<C-r>`: rename the tag under the cursor
+
+
+FZF-LUA ~
+
+You can use fzf-lua <https://github.com/ibhagwan/fzf-lua> as a fuzzy picker
+for your tagged files.
+
+>lua
+    require("grapple").open_fzf()
+    -- or for a specific scope:
+    require("grapple").open_fzf({ scope = "global" })
+<
+
+Or via the Grapple command:
+
+>vim
+    :Grapple open_fzf
+<
+
+Inside the picker:
+
+- `<cr>`: select the tag
+- `<C-x>`: delete the selected tag(s) (multi-select with `<Tab>`)
+- `<C-r>`: rename the tag under the cursor
+
 
 TELESCOPE ~
 
@@ -979,6 +1036,11 @@ window
 >vim
     :Telescope grapple tags
 <
+
+Inside the picker:
+
+- `<cr>`: select the tag
+- `<C-X>`: delete the tag under the cursor
 
 
 STATUSLINE ~

--- a/lua/grapple.lua
+++ b/lua/grapple.lua
@@ -251,6 +251,20 @@ function Grapple.toggle_tags(opts)
     return toggle(Grapple.open_tags, opts)
 end
 
+---Open a snacks.nvim fuzzy picker for all tags in the current scope.
+---Requires snacks.nvim to be installed.
+---@param opts? { scope?: string, id?: string }
+function Grapple.open_snacks(opts)
+    require("grapple.extensions.snacks").open_tags(opts)
+end
+
+---Open a fzf-lua fuzzy picker for all tags in the current scope.
+---Requires fzf-lua to be installed.
+---@param opts? { scope?: string, id?: string }
+function Grapple.open_fzf(opts)
+    require("grapple.extensions.fzf_lua").open_tags(opts)
+end
+
 ---Open a floating window populated with all defined scopes
 ---@param opts? { all: boolean }
 function Grapple.open_scopes(opts)

--- a/lua/grapple/extensions/fzf_lua.lua
+++ b/lua/grapple/extensions/fzf_lua.lua
@@ -1,0 +1,111 @@
+local Grapple = require("grapple")
+
+local M = {}
+
+---Build a reverse-lookup table from entry string to tag.
+---Entries are formatted as "path:lnum:col" for the builtin previewer.
+---@param tags grapple.tag[]
+---@return string[], table<string, grapple.tag>
+local function build_entries(tags)
+    local entries = {}
+    local lookup = {} -- entry string -> tag
+    for _, tag in ipairs(tags) do
+        local cursor = tag.cursor or { 1, 0 }
+        local entry = string.format("%s:%d:%d", tag.path, cursor[1], cursor[2] + 1)
+        table.insert(entries, entry)
+        lookup[entry] = tag
+        -- also index by plain path as a fallback
+        lookup[tag.path] = tag
+    end
+    return entries, lookup
+end
+
+---Resolve selected fzf entry back to a tag using the lookup table.
+---@param line string
+---@param lookup table<string, grapple.tag>
+---@return grapple.tag | nil
+local function get_tag(line, lookup)
+    if lookup[line] then
+        return lookup[line]
+    end
+    -- strip trailing :lnum:col
+    local path = line:match("^(.+):%d+:%d+$") or line:match("^(.+):%d+$") or line
+    return lookup[path]
+end
+
+---@param opts? { scope?: string, id?: string }
+function M.open_tags(opts)
+    opts = opts or {}
+
+    local tags, err = Grapple.tags({ scope = opts.scope, id = opts.id })
+    if not tags then
+        ---@diagnostic disable-next-line: param-type-mismatch
+        vim.notify(err, vim.log.levels.ERROR)
+        return
+    end
+
+    if #tags == 0 then
+        vim.notify("No tags in current scope", vim.log.levels.INFO)
+        return
+    end
+
+    local picker_opts = opts
+    local entries, lookup = build_entries(tags)
+
+    require("fzf-lua").fzf_exec(entries, {
+        prompt = "Grapple> ",
+        previewer = "builtin",
+        fzf_opts = { ["--multi"] = true },
+        actions = {
+            ["default"] = function(selected)
+                if not selected or #selected == 0 then
+                    return
+                end
+                local tag = get_tag(selected[1], lookup)
+                if tag then
+                    Grapple.select({ path = tag.path, scope = picker_opts.scope, scope_id = picker_opts.id })
+                end
+            end,
+            ["ctrl-x"] = function(selected)
+                if not selected or #selected == 0 then
+                    return
+                end
+                for _, line in ipairs(selected) do
+                    local tag = get_tag(line, lookup)
+                    if tag then
+                        Grapple.untag({ path = tag.path, scope = picker_opts.scope, scope_id = picker_opts.id })
+                    end
+                end
+                vim.schedule(function()
+                    M.open_tags(picker_opts)
+                end)
+            end,
+            ["ctrl-r"] = function(selected)
+                if not selected or #selected == 0 then
+                    return
+                end
+                local tag = get_tag(selected[1], lookup)
+                if not tag then
+                    return
+                end
+                local path = tag.path
+                local Path = require("grapple.path")
+                vim.schedule(function()
+                    vim.ui.input({ prompt = string.format("Rename %s: ", Path.fs_short(path)) }, function(name)
+                        if name == nil then
+                            return
+                        end
+                        Grapple.tag({
+                            path = path,
+                            name = name ~= "" and name or nil,
+                            scope_id = picker_opts.id,
+                        })
+                        M.open_tags(picker_opts)
+                    end)
+                end)
+            end,
+        },
+    })
+end
+
+return M

--- a/lua/grapple/extensions/snacks.lua
+++ b/lua/grapple/extensions/snacks.lua
@@ -1,0 +1,103 @@
+local Grapple = require("grapple")
+
+local M = {}
+
+---@param opts? { scope?: string, id?: string }
+function M.open_tags(opts)
+    opts = opts or {}
+
+    local tags, err = Grapple.tags({ scope = opts.scope, id = opts.id })
+    if not tags then
+        ---@diagnostic disable-next-line: param-type-mismatch
+        vim.notify(err, vim.log.levels.ERROR)
+        return
+    end
+
+    if #tags == 0 then
+        vim.notify("No tags in current scope", vim.log.levels.INFO)
+        return
+    end
+
+    local picker_opts = opts
+
+    local items = {}
+    for i, tag in ipairs(tags) do
+        local cursor = tag.cursor or { 1, 0 }
+        local short = vim.fn.fnamemodify(tag.path, ":~:.")
+        local text = tag.name and ("[" .. tag.name .. "] " .. short) or short
+        table.insert(items, {
+            idx = i,
+            score = i,
+            text = text,
+            file = tag.path,
+            pos = { cursor[1], cursor[2] },
+            -- private: accessed in actions
+            _path = tag.path,
+            _name = tag.name,
+        })
+    end
+
+    require("snacks").picker.pick({
+        title = "Grapple Tags",
+        items = items,
+        format = function(item, _)
+            local short = vim.fn.fnamemodify(item._path, ":~:.")
+            if item._name then
+                return {
+                    { "[" .. item._name .. "] ", "GrappleName" },
+                    { short, "Normal" },
+                }
+            end
+            return { { short, "Normal" } }
+        end,
+        preview = "file",
+        confirm = function(self, item)
+            self:close()
+            if item then
+                Grapple.select({ path = item._path, scope = picker_opts.scope, scope_id = picker_opts.id })
+            end
+        end,
+        actions = {
+            delete_tag = function(self, item)
+                if item then
+                    Grapple.untag({ path = item._path, scope = picker_opts.scope, scope_id = picker_opts.id })
+                end
+                self:close()
+                vim.schedule(function()
+                    M.open_tags(picker_opts)
+                end)
+            end,
+            rename_tag = function(self, item)
+                if not item then
+                    return
+                end
+                local path = item._path
+                self:close()
+                local Path = require("grapple.path")
+                vim.schedule(function()
+                    vim.ui.input({ prompt = string.format("Rename %s: ", Path.fs_short(path)) }, function(name)
+                        if name == nil then
+                            return
+                        end
+                        Grapple.tag({
+                            path = path,
+                            name = name ~= "" and name or nil,
+                            scope_id = picker_opts.id,
+                        })
+                        M.open_tags(picker_opts)
+                    end)
+                end)
+            end,
+        },
+        win = {
+            input = {
+                keys = {
+                    ["<C-x>"] = { "delete_tag", mode = { "n", "i" }, desc = "Delete tag" },
+                    ["<C-r>"] = { "rename_tag", mode = { "n", "i" }, desc = "Rename tag" },
+                },
+            },
+        },
+    })
+end
+
+return M

--- a/lua/grapple/settings.lua
+++ b/lua/grapple/settings.lua
@@ -55,6 +55,13 @@ local DEFAULT_SETTINGS = {
     ---@type integer | string
     prune = "30d",
 
+    ---Fuzzy picker to open when pressing <C-f> inside the Grapple tags window.
+    ---Supported values: "snacks" | "fzf_lua" | "telescope" | "auto" | false
+    ---"auto" tries snacks -> fzf-lua -> telescope in order of availability.
+    ---Set to false to disable the <C-f> keymap entirely.
+    ---@type string | false
+    fuzzy_picker = "auto",
+
     ---@class grapple.scope_definition
     ---@field name string
     ---@field resolver grapple.scope_resolver
@@ -227,6 +234,13 @@ local DEFAULT_SETTINGS = {
             local path = entry.data.path
             window:perform_retain(TagActions.rename, { path = path })
         end, { desc = "Rename" })
+
+        -- Open fuzzy picker (snacks / fzf-lua / telescope)
+        if app.settings.fuzzy_picker ~= false then
+            window:map("n", "<c-f>", function()
+                window:perform_close(TagActions.open_fuzzy_picker)
+            end, { desc = "Open fuzzy picker" })
+        end
 
         -- Help
         window:map("n", "?", function()

--- a/lua/grapple/tag_actions.lua
+++ b/lua/grapple/tag_actions.lua
@@ -62,4 +62,56 @@ function TagActions.open_scopes()
     require("grapple").open_scopes()
 end
 
+---Open the configured fuzzy picker for the current scope.
+---Picker is selected by settings.fuzzy_picker ("snacks", "fzf_lua",
+---"telescope", "auto"). With "auto" the order is snacks -> fzf-lua -> telescope.
+---@param opts grapple.action.tag_options
+---@return string? error
+function TagActions.open_fuzzy_picker(opts)
+    local scope = opts.scope
+    local picker = require("grapple").app().settings.fuzzy_picker
+    local picker_opts = { scope = scope.name, id = scope.id }
+
+    local function try_snacks()
+        local ok = pcall(require, "snacks")
+        if not ok then
+            return false
+        end
+        require("grapple.extensions.snacks").open_tags(picker_opts)
+        return true
+    end
+
+    local function try_fzf_lua()
+        local ok = pcall(require, "fzf-lua")
+        if not ok then
+            return false
+        end
+        require("grapple.extensions.fzf_lua").open_tags(picker_opts)
+        return true
+    end
+
+    local function try_telescope()
+        local ok = pcall(require, "telescope")
+        if not ok then
+            return false
+        end
+        require("telescope").extensions.grapple.tags()
+        return true
+    end
+
+    if picker == "snacks" then
+        try_snacks()
+    elseif picker == "fzf_lua" then
+        try_fzf_lua()
+    elseif picker == "telescope" then
+        try_telescope()
+    elseif picker == "auto" then
+        if not try_snacks() then
+            if not try_fzf_lua() then
+                try_telescope()
+            end
+        end
+    end
+end
+
 return TagActions


### PR DESCRIPTION
## Summary

- Add `lua/grapple/extensions/snacks.lua` and `lua/grapple/extensions/fzf_lua.lua`
  picker adapters, mirroring telescope's tag selection (`<CR>`), deletion (`<C-x>`),
  and rename (`<C-r>`) actions
- Add `<C-f>` keymap inside the Grapple tags window to hand off to a fuzzy picker;
  controlled by the new `fuzzy_picker` setting (default `"auto"`)
- Add `Grapple.open_snacks()` and `Grapple.open_fzf()` to the public API and
  `:Grapple open_snacks` / `:Grapple open_fzf` commands
- Update `README.md` and `doc/grapple.txt` with integration docs and new default
  settings entry

## Details

The `fuzzy_picker = "auto"` setting selects the first available picker at runtime
in the order: snacks -> fzf-lua -> telescope. Set to a specific string to pin the
picker, or `false` to disable `<C-f>` entirely.

The snacks adapter passes `file` and `pos` fields for native file preview with
cursor positioning. The fzf-lua adapter uses `path:lnum:col` entry format, which
the builtin previewer parses for cursor placement, with a reverse-lookup table to
map selected entries back to tags.